### PR TITLE
Drop postscript glyph names for TTFs; add --keep-glyph-names option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ attrs==19.3.0             # via ufolib2
 booleanoperations==0.9.0  # via ufo2ft
 compreffor==0.5.0         # via ufo2ft
 cu2qu==1.6.7              # via ufo2ft
-fonttools[ufo]==4.9.0     # via booleanoperations, compreffor, cu2qu, nanoemoji (setup.py), ufo2ft, ufolib2
+fonttools[ufo]==4.12.0    # via booleanoperations, compreffor, cu2qu, nanoemoji (setup.py), ufo2ft, ufolib2
 fs==2.4.11                # via fonttools
 lxml==4.5.0               # via nanoemoji (setup.py), picosvg
 picosvg==0.3.8            # via nanoemoji (setup.py)
@@ -19,7 +19,7 @@ pytz==2020.1              # via fs
 regex==2020.5.14           # via nanoemoji (setup.py)
 six==1.14.0               # via absl-py, fs
 skia-pathops==0.4.1       # via picosvg
-ufo2ft==2.14.0            # via nanoemoji (setup.py)
+ufo2ft==2.15.0            # via nanoemoji (setup.py)
 ufolib2==0.6.2            # via nanoemoji (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "absl-py>=0.9.0",
-        "fonttools[ufo]>=4.9.0",
+        "fonttools[ufo]>=4.12.0",
         "lxml>=4.0",
         "picosvg>=0.3.8",
         "regex>=2020.4.4",
-        "ufo2ft>=2.13.0",
+        "ufo2ft>=2.15.0",
         "ufoLib2>=0.6.2",
         "dataclasses>=0.7; python_version < '3.7'",
     ],

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -59,6 +59,7 @@ class ColorFontConfig(NamedTuple):
     family: str
     color_format: str
     output_format: str
+    keep_glyph_names: bool = True
 
 
 class InputGlyph(NamedTuple):
@@ -111,6 +112,9 @@ flags.DEFINE_string(
     "/tmp/AnEmojiFamily-Regular.ttf",
     "Dest file, can be .ttf, .otf, or .ufo",
 )
+flags.DEFINE_bool(
+    "keep_glyph_names", True, "Whether or not to store glyph names in the font."
+)
 
 
 def _codepoints_from_filename(filename):
@@ -137,7 +141,7 @@ def _inputs(filenames: Iterable[str]) -> Generator[InputGlyph, None, None]:
             yield InputGlyph(filename, codepoints, picosvg)
 
 
-def _ufo(family: str, upem: int) -> ufoLib2.Font:
+def _ufo(family: str, upem: int, keep_glyph_names: bool = True) -> ufoLib2.Font:
     ufo = ufoLib2.Font()
     ufo.info.familyName = family
     # set various font metadata; see the full list of fontinfo attributes at
@@ -150,6 +154,10 @@ def _ufo(family: str, upem: int) -> ufoLib2.Font:
     space.unicodes = [0x0020]
     space.width = upem
     ufo.glyphOrder = [".notdef", ".space"]
+
+    if not keep_glyph_names:
+        # use 'post' format 3.0 for TTFs, shaving a kew KBs of unneeded glyph names
+        ufo.lib[ufo2ft.constants.KEEP_GLYPH_NAMES] = keep_glyph_names
 
     return ufo
 
@@ -210,6 +218,7 @@ def _create_glyph(color_glyph: ColorGlyph, painted_layer: PaintedLayer) -> Glyph
     ufo = color_glyph.ufo
 
     glyph = ufo.newGlyph(_next_name(ufo, lambda i: f"{color_glyph.glyph_name}.{i}"))
+    glyph_names = [glyph.name]
     glyph.width = ufo.info.unitsPerEm
 
     svg_units_to_font_units = color_glyph.transform_for_font_space()
@@ -219,6 +228,7 @@ def _create_glyph(color_glyph: ColorGlyph, painted_layer: PaintedLayer) -> Glyph
         base_glyph = ufo.newGlyph(
             _next_name(ufo, lambda i: f"{glyph.name}.component.{i}")
         )
+        glyph_names.append(base_glyph.name)
 
         _draw(painted_layer.path, base_glyph, svg_units_to_font_units)
 
@@ -234,11 +244,13 @@ def _create_glyph(color_glyph: ColorGlyph, painted_layer: PaintedLayer) -> Glyph
                 f=transform.f * svg_units_to_font_units.d,
             )
             glyph.components.append(
-                Component(baseGlyph=base_glyph.name, transformation=transform,)
+                Component(baseGlyph=base_glyph.name, transformation=transform)
             )
     else:
         # Not a composite, just draw directly on the glyph
         _draw(painted_layer.path, glyph, svg_units_to_font_units)
+
+    ufo.glyphOrder += glyph_names
 
     return glyph
 
@@ -360,8 +372,8 @@ def _svg_ttfont(ufo, color_glyphs, ttfont, zip=False):
             .remove_attributes(("enable-background",))
             # Required to match gid
             .set_attributes((("id", f"glyph{c.glyph_id}"),)).tostring(),
-            ttfont.getGlyphID(c.glyph_name),
-            ttfont.getGlyphID(c.glyph_name),
+            c.glyph_id,
+            c.glyph_id,
         )
         for c in color_glyphs
     ]
@@ -413,7 +425,7 @@ def _ensure_codepoints_will_have_glyphs(ufo, glyph_inputs):
 
 def _generate_color_font(config: ColorFontConfig, inputs: Iterable[InputGlyph]):
     """Make a UFO and optionally a TTFont from svgs."""
-    ufo = _ufo(config.family, config.upem)
+    ufo = _ufo(config.family, config.upem, config.keep_glyph_names)
     _ensure_codepoints_will_have_glyphs(ufo, inputs)
 
     base_gid = len(ufo.glyphOrder)
@@ -445,6 +457,7 @@ def _run(argv):
         family=FLAGS.family,
         color_format=FLAGS.color_format,
         output_format=os.path.splitext(FLAGS.output_file)[1],
+        keep_glyph_names=FLAGS.keep_glyph_names,
     )
 
     inputs = list(_inputs(argv[1:]))

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -59,7 +59,7 @@ class ColorFontConfig(NamedTuple):
     family: str
     color_format: str
     output_format: str
-    keep_glyph_names: bool = True
+    keep_glyph_names: bool = False
 
 
 class InputGlyph(NamedTuple):
@@ -113,7 +113,7 @@ flags.DEFINE_string(
     "Dest file, can be .ttf, .otf, or .ufo",
 )
 flags.DEFINE_bool(
-    "keep_glyph_names", True, "Whether or not to store glyph names in the font."
+    "keep_glyph_names", False, "Whether or not to store glyph names in the font."
 )
 
 
@@ -141,7 +141,7 @@ def _inputs(filenames: Iterable[str]) -> Generator[InputGlyph, None, None]:
             yield InputGlyph(filename, codepoints, picosvg)
 
 
-def _ufo(family: str, upem: int, keep_glyph_names: bool = True) -> ufoLib2.Font:
+def _ufo(family: str, upem: int, keep_glyph_names: bool = False) -> ufoLib2.Font:
     ufo = ufoLib2.Font()
     ufo.info.familyName = family
     # set various font metadata; see the full list of fontinfo attributes at
@@ -155,9 +155,8 @@ def _ufo(family: str, upem: int, keep_glyph_names: bool = True) -> ufoLib2.Font:
     space.width = upem
     ufo.glyphOrder = [".notdef", ".space"]
 
-    if not keep_glyph_names:
-        # use 'post' format 3.0 for TTFs, shaving a kew KBs of unneeded glyph names
-        ufo.lib[ufo2ft.constants.KEEP_GLYPH_NAMES] = keep_glyph_names
+    # use 'post' format 3.0 for TTFs, shaving a kew KBs of unneeded glyph names
+    ufo.lib[ufo2ft.constants.KEEP_GLYPH_NAMES] = keep_glyph_names
 
     return ufo
 

--- a/tests/make_emoji_font_test.py
+++ b/tests/make_emoji_font_test.py
@@ -73,3 +73,23 @@ def test_make_emoji_font(svgs, expected_ttx, color_format, output_format):
     )
     _, ttfont = nanoemoji._generate_color_font(config, glyph_inputs)
     test_helper.assert_expected_ttx(svgs, ttfont, expected_ttx)
+
+
+@pytest.mark.parametrize(
+    "svgs", [("rect.svg", "rect2.svg"), ("one-o-clock.svg", "two-o-clock.svg")]
+)
+@pytest.mark.parametrize("color_format", ["colr_0", "colr_1", "svg", "svgz"])
+@pytest.mark.parametrize("keep_glyph_names", [True, False])
+def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
+    config, glyph_inputs = test_helper.color_font_config(
+        color_format, svgs, ".ttf", keep_glyph_names=keep_glyph_names
+    )
+    ufo, ttfont = nanoemoji._generate_color_font(config, glyph_inputs)
+
+    assert len(ufo.glyphOrder) == len(ttfont.getGlyphOrder())
+    if keep_glyph_names:
+        assert ttfont["post"].formatType == 2.0
+        assert ufo.glyphOrder == ttfont.getGlyphOrder()
+    else:
+        assert ttfont["post"].formatType == 3.0
+        assert ufo.glyphOrder != ttfont.getGlyphOrder()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -31,7 +31,7 @@ def picosvg(filename):
     return SVG.parse(locate_test_file(filename)).topicosvg()
 
 
-def color_font_config(color_format, svgs, output_format):
+def color_font_config(color_format, svgs, output_format, keep_glyph_names=True):
     print(svgs)
     return (
         nanoemoji.ColorFontConfig(
@@ -39,6 +39,7 @@ def color_font_config(color_format, svgs, output_format):
             family="UnitTest",
             color_format=color_format,
             output_format=output_format,
+            keep_glyph_names=keep_glyph_names,
         ),
         [
             nanoemoji.InputGlyph(svg, (0xE000 + idx,), picosvg(svg))


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/30

[ufo2ft 2.15](https://github.com/googlefonts/ufo2ft/releases/tag/v2.15.0) added support for dropping postscript glyph names from TTFs by setting the compiled font's `post` table to format 3.0.

For CFF-flavored OTF, ufo2ft still doesn't allow to remove glyph names, as these are embedded in the CFF table itself and required. Maybe in the future we will be able to convert from name-keyed CFF to CID-keyed CFF (haven't looked into it yet).

This PR also adds a `--nokeep_glyph_names` flag to the nanoemoji script. I decided not to drop glyph names by default as this would change all the TTX test files, besides it's good to keep the glyph names for debugging purposes and only drop them when making final fonts.