### PR TITLE
flip y_scale sign before translating in map_viewbox_to_font_emsqure

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -49,10 +49,10 @@ def _shift_origin_0_0(
 
 def map_viewbox_to_font_emsquare(view_box: Rect, upem: int) -> Affine2D:
     x_scale, y_scale = _scale_viewbox_to_emsquare(view_box, upem)
-    dx, dy = _shift_origin_0_0(view_box, x_scale, y_scale)
-
-    # flip y axis and shift so things are in the right place
+    # flip y axis
     y_scale = -y_scale
+    # shift so things are in the right place
+    dx, dy = _shift_origin_0_0(view_box, x_scale, y_scale)
     dy = dy + upem
     return Affine2D(x_scale, 0, 0, y_scale, dx, dy)
 

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -46,13 +46,13 @@ def _nsvg(filename):
         ("0 0 1024 1024", 1024, Affine2D(1, 0, 0, -1, 0, 1024)),
         # noto emoji norm. scale, flip y
         ("0 0 128 128", 1024, Affine2D(8, 0, 0, -8, 0, 1024)),
-        # noto emoji emoji_u26be.svg viewBox. Scale, translate, flip y
-        ("-151 297 128 128", 1024, Affine2D(8, 0, 0, -8, 1208, -1352)),
+        # noto emoji emoji_u26be.svg viewBox. Scale, flip y and translate
+        ("-151 297 128 128", 1024, Affine2D(8, 0, 0, -8, 1208, 3400)),
         # made up example. Scale, translate, flip y
         (
             "10 11 20 21",
             100,
-            Affine2D(a=5.0, b=0, c=0, d=-4.761905, e=-50.0, f=47.619048),
+            Affine2D(a=5.0, b=0, c=0, d=-4.761905, e=-50.0, f=152.380952),
         ),
     ],
 )


### PR DESCRIPTION
Otherwise we translate in the wrong direction.
This finally fixes the odd viewBox of the baseball noto-emoji (emoji_u26BE.svg), which as you remember doesn't start at 0,0.
I can see it properly after I roundtrip it back from COLRv1 to SVG (in progress #11).

