### PR TITLE
[svg] decompile all tables before changing TTFont glyph order

### DIFF
--- a/tests/clocks_rects_picosvg.ttx
+++ b/tests/clocks_rects_picosvg.ttx
@@ -25,15 +25,15 @@
     <cmap_format_4 platformID="0" platEncID="3" language="0">
       <map code="0x20" name=".space"/><!-- SPACE -->
       <map code="0xe000" name="e000"/><!-- ???? -->
-      <map code="0xe001" name="e002"/><!-- ???? -->
-      <map code="0xe002" name="e001"/><!-- ???? -->
+      <map code="0xe001" name="e001"/><!-- ???? -->
+      <map code="0xe002" name="e002"/><!-- ???? -->
       <map code="0xe003" name="e003"/><!-- ???? -->
     </cmap_format_4>
     <cmap_format_4 platformID="3" platEncID="1" language="0">
       <map code="0x20" name=".space"/><!-- SPACE -->
       <map code="0xe000" name="e000"/><!-- ???? -->
-      <map code="0xe001" name="e002"/><!-- ???? -->
-      <map code="0xe002" name="e001"/><!-- ???? -->
+      <map code="0xe001" name="e001"/><!-- ???? -->
+      <map code="0xe002" name="e002"/><!-- ???? -->
       <map code="0xe003" name="e003"/><!-- ???? -->
     </cmap_format_4>
   </cmap>


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/113

When reusing glyph shapes in OT-SVG, we change the order of glyphs so that those belonging to the same group have contiguous glyph indexes.
However, when modifying a TTFont's glyphOrder, we must also make sure that all the tables that reference glyphs by index are also re-compiled with this updated order, otherwise some tables may keep using the old order (e.g. cmap mapping to wrong glyph, or GSUB substituting the wrong glyph etc.).

Once FontTools provides a better API for reordering glyphs we'll make use of that, see https://github.com/fonttools/fonttools/issues/2060