### PR TITLE
Use ninja '@'-prefixed response files to fix 'argument list too long'

### DIFF
--- a/src/nanoemoji/util.py
+++ b/src/nanoemoji/util.py
@@ -14,9 +14,35 @@
 
 """Small helper functions."""
 
+import pathlib
+import shlex
+from typing import List
+
 
 def only(filter_fn, iterable):
     it = filter(filter_fn, iterable)
     result = next(it)
     assert next(it, None) is None
+    return result
+
+
+def expand_ninja_response_files(argv: List[str]) -> List[str]:
+    """
+    Extend argument list with MSVC-style '@'-prefixed response files.
+
+    Ninja build rules support this mechanism to allow passing a very long list of inputs
+    that may exceed the shell's maximum command-line length.
+
+    References:
+    https://ninja-build.org/manual.html ("Rule variables")
+    https://docs.microsoft.com/en-us/cpp/build/reference/at-specify-a-compiler-response-file
+    """
+    result = []
+    for arg in argv:
+        if arg.startswith("@"):
+            with open(arg[1:], "r") as rspfile:
+                rspfile_content = rspfile.read()
+            result.extend(shlex.split(rspfile_content))
+        else:
+            result.append(arg)
     return result

--- a/src/nanoemoji/write_codepoints.py
+++ b/src/nanoemoji/write_codepoints.py
@@ -16,10 +16,11 @@
 
 from absl import app
 from nanoemoji import codepoints
+from nanoemoji import util
 
 
 def main(argv):
-    for svg_file in argv[1:]:
+    for svg_file in util.expand_ninja_response_files(argv[1:]):
         print(codepoints.csv_line(svg_file))
 
 

--- a/src/nanoemoji/write_diffreport.py
+++ b/src/nanoemoji/write_diffreport.py
@@ -20,6 +20,7 @@ import functools
 from PIL import Image, ImageChops, ImageStat
 from pathlib import Path
 from textwrap import dedent
+from nanoemoji import util
 
 
 FLAGS = flags.FLAGS
@@ -46,7 +47,9 @@ def _rhs(diff_file):
 
 
 def main(argv):
-    diff_files = (Path(diff_file) for diff_file in argv[1:])
+    diff_files = (
+        Path(diff_file) for diff_file in util.expand_ninja_response_files(argv[1:])
+    )
     diff_files = sorted(diff_files, key=_diff_value, reverse=True)
     with open(FLAGS.output_file, "w") as f:
         f.write(

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -469,6 +469,8 @@ def output_file(family, output, color_format):
 
 
 def main(argv):
+    argv = util.expand_ninja_response_files(argv)
+
     config = ColorFontConfig(
         upem=FLAGS.upem,
         family=FLAGS.family,


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/110