### PR TITLE
Fix problems found trying to build color-fonts repo updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "absl-py>=0.9.0",
         "dataclasses>=0.8; python_version < '3.7'",
         "fonttools[ufo]>=4.17.0",
-        "importlib_resources>=3.3.0; python_version < '3.9'",
+        "importlib_resources>=3.3.0",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
         "picosvg>=0.7.1",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "picosvg>=0.7.1",
         "pillow>=7.2.0",
         "regex>=2020.4.4",
+        "toml>=0.10.1",
         "ufo2ft[cffsubr]>=2.15.0",
         "ufoLib2>=0.6.2",
     ],

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -33,7 +33,7 @@ from picosvg.svg_reuse import normalize, affine_between
 from picosvg.svg_transform import Affine2D
 from picosvg.svg import SVG
 from picosvg.svg_types import SVGPath, SVGLinearGradient, SVGRadialGradient
-from typing import Generator, NamedTuple, Tuple
+from typing import Generator, NamedTuple, Optional, Tuple
 import ufoLib2
 
 
@@ -312,7 +312,7 @@ class ColorGlyph(NamedTuple):
     glyph_name: str
     glyph_id: int
     codepoints: Tuple[int, ...]
-    painted_layers: Tuple[PaintedLayer, ...]
+    painted_layers: Optional[Tuple[PaintedLayer, ...]]  # None for untouched formats
     svg: SVG  # picosvg except for untouched formats
 
     @staticmethod
@@ -327,7 +327,7 @@ class ColorGlyph(NamedTuple):
             base_glyph.unicode = next(iter(codepoints))
 
         # Grab the transform + (color, glyph) layers for COLR
-        painted_layers = ()
+        painted_layers = None
         if extract_layers:
             painted_layers = tuple(_painted_layers(filename, ufo.info.unitsPerEm, svg))
         return ColorGlyph(

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -313,10 +313,10 @@ class ColorGlyph(NamedTuple):
     glyph_id: int
     codepoints: Tuple[int, ...]
     painted_layers: Tuple[PaintedLayer, ...]
-    picosvg: SVG
+    svg: SVG  # picosvg except for untouched formats
 
     @staticmethod
-    def create(ufo, filename, glyph_id, codepoints, picosvg):
+    def create(ufo, filename, glyph_id, codepoints, svg, extract_layers=True):
         logging.debug(" ColorGlyph for %s (%s)", filename, codepoints)
         glyph_name = glyph.glyph_name(codepoints)
         base_glyph = ufo.newGlyph(glyph_name)
@@ -327,13 +327,15 @@ class ColorGlyph(NamedTuple):
             base_glyph.unicode = next(iter(codepoints))
 
         # Grab the transform + (color, glyph) layers for COLR
-        painted_layers = tuple(_painted_layers(filename, ufo.info.unitsPerEm, picosvg))
+        painted_layers = ()
+        if extract_layers:
+            painted_layers = tuple(_painted_layers(filename, ufo.info.unitsPerEm, svg))
         return ColorGlyph(
-            ufo, filename, glyph_name, glyph_id, codepoints, painted_layers, picosvg
+            ufo, filename, glyph_name, glyph_id, codepoints, painted_layers, svg
         )
 
     def _has_viewbox_for_transform(self) -> bool:
-        view_box = self.picosvg.view_box()
+        view_box = self.svg.view_box()
         if view_box is None:
             logging.warning(
                 f"{self.ufo.info.familyName} has no viewBox; no transform will be applied"
@@ -345,7 +347,7 @@ class ColorGlyph(NamedTuple):
         if not self._has_viewbox_for_transform():
             return Affine2D.identity()
         return map_viewbox_to_font_emsquare(
-            self.picosvg.view_box(), self.ufo.info.unitsPerEm
+            self.svg.view_box(), self.ufo.info.unitsPerEm
         )
 
     def transform_for_otsvg_space(self):
@@ -353,7 +355,7 @@ class ColorGlyph(NamedTuple):
         if not self._has_viewbox_for_transform():
             return Affine2D.identity()
         return map_viewbox_to_otsvg_emsquare(
-            self.picosvg.view_box(), self.ufo.info.unitsPerEm
+            self.svg.view_box(), self.ufo.info.unitsPerEm
         )
 
     def paints(self):

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -151,11 +151,11 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         if "srcs" in master_config:
             for src in master_config.pop("srcs"):
                 if Path(src).is_file():
-                    srcs.add(Path(src))
+                    srcs.add(Path(src).resolve())
                 elif config_dir is None:
                     raise ValueError(f"No config dir, unable to resolve {src}")
                 else:
-                    srcs |= set(config_dir.glob(src))
+                    srcs |= set(p.resolve() for p in config_dir.glob(src))
         if additional_srcs is not None:
             srcs |= set(additional_srcs)
         srcs = tuple(sorted(srcs))

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 from absl import flags
-try:
-    import importlib.resources as resources
-except ImportError:
-    import importlib_resources as resources
+
+# works even on py39
+import importlib_resources as resources
+
+# does NOT work on py39; resources.path (and .contents) don't admit our resources exist
+# try:
+#     import importlib.resources as resources
+# except ImportError:
+#     import importlib_resources as resources
 from pathlib import Path
 import toml
 from typing import Any, MutableMapping, NamedTuple, Optional, Tuple, Sequence

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from absl import flags
-import importlib_resources
-
 try:
     import importlib.resources as resources
 except ImportError:

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -33,6 +33,7 @@ from absl import logging
 import glob
 from nanoemoji import codepoints, config, write_font
 from nanoemoji.config import AxisPosition, FontConfig, MasterConfig
+from nanoemoji.util import fs_root, rel
 from ninja import ninja_syntax
 import os
 from pathlib import Path
@@ -60,15 +61,6 @@ def self_dir() -> Path:
 
 def build_dir() -> Path:
     return Path(FLAGS.build_dir).resolve()
-
-
-def fs_root() -> Path:
-    return Path("/").resolve()
-
-
-def rel(from_path: Path, to_path: Path) -> Path:
-    # relative_to(A,B) doesn't like it if B doesn't start with A
-    return Path(os.path.relpath(str(to_path.resolve()), str(from_path.resolve())))
 
 
 def rel_self(path: Path) -> Path:

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -295,25 +295,23 @@ def write_variable_font_build(nw: ninja_syntax.Writer, font_config: FontConfig):
     nw.newline()
 
 
-def _font_config_for_build(cli_srcs):
+def _write_config_for_build(font_config: FontConfig):
     # Dump config with defaults, CLI args, etc resolved to build
     # and sources updated to point to build picosvgs
-    original_config = config.load(additional_srcs=cli_srcs)
-    font_config = _update_sources(original_config)
+    font_config = _update_sources(font_config)
 
-    # Save it so we can point write_font at it later
     config_file = build_dir() / "config.toml"
     config.write(config_file, font_config)
     print("Wrote ", config_file)
-    return original_config
 
 
 def _run(argv):
     os.makedirs(build_dir(), exist_ok=True)
 
-    font_config = _font_config_for_build(
-        tuple(Path(f) for f in argv if f.endswith(".svg"))
+    font_config = config.load(
+        additional_srcs=tuple(Path(f) for f in argv if f.endswith(".svg"))
     )
+    _write_config_for_build(font_config)
 
     is_vf = len(font_config.masters) > 1
     is_svg = font_config.color_format.endswith(

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -85,7 +85,7 @@ def _glyph_groups(color_glyphs: Sequence[ColorGlyph]) -> Tuple[Tuple[str, ...]]:
         reuse_groups.make_set(color_glyph.glyph_name)
         for painted_layer in color_glyph.painted_layers:
             reuse_key = _inter_glyph_reuse_key(
-                color_glyph.picosvg.view_box(), painted_layer
+                color_glyph.svg.view_box(), painted_layer
             )
             if reuse_key not in glyphs:
                 glyphs[reuse_key] = color_glyph.glyph_name
@@ -296,7 +296,7 @@ def _add_glyph(svg: SVG, color_glyph: ColorGlyph, reuse_cache: ReuseCache):
     svg_g = svg.append_to("/svg:svg", etree.Element("g"))
     svg_g.attrib["id"] = f"glyph{color_glyph.glyph_id}"
 
-    view_box = color_glyph.picosvg.view_box()
+    view_box = color_glyph.svg.view_box()
     if view_box is None:
         raise ValueError(f"{color_glyph.filename} must declare view box")
 

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -327,8 +327,7 @@ def _add_glyph(svg: SVG, color_glyph: ColorGlyph, reuse_cache: ReuseCache):
                     svg_use.attrib["y"] = _ntos(ty)
                 transform = reuse.translate(-tx, -ty)
                 if transform != Affine2D.identity():
-                    # TODO apply scale and rotation. Just slap a transform on the <use>?
-                    raise NotImplementedError("TODO apply scale & rotation to use")
+                    svg_use.attrib["transform"] = _svg_matrix(transform)
 
         else:
             el = reuse_cache.shapes[reuse_key]

--- a/src/nanoemoji/util.py
+++ b/src/nanoemoji/util.py
@@ -14,7 +14,8 @@
 
 """Small helper functions."""
 
-import pathlib
+import os
+from pathlib import Path
 import shlex
 from typing import List
 
@@ -46,3 +47,12 @@ def expand_ninja_response_files(argv: List[str]) -> List[str]:
         else:
             result.append(arg)
     return result
+
+
+def fs_root() -> Path:
+    return Path("/").resolve()
+
+
+def rel(from_path: Path, to_path: Path) -> Path:
+    # relative_to(A,B) doesn't like it if B doesn't start with A
+    return Path(os.path.relpath(str(to_path.resolve()), str(from_path.resolve())))

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -67,7 +67,7 @@ FLAGS = flags.FLAGS
 class InputGlyph(NamedTuple):
     filename: Path
     codepoints: Tuple[int, ...]
-    picosvg: SVG
+    svg: SVG  # picosvg except for untouched formats
 
 
 # A color font generator.
@@ -472,8 +472,15 @@ def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
 
     base_gid = len(ufo.glyphOrder)
     color_glyphs = [
-        ColorGlyph.create(ufo, filename, base_gid + idx, codepoints, psvg)
-        for idx, (filename, codepoints, psvg) in enumerate(inputs)
+        ColorGlyph.create(
+            ufo,
+            filename,
+            base_gid + idx,
+            codepoints,
+            svg,
+            extract_layers=config.has_picosvgs,
+        )
+        for idx, (filename, codepoints, svg) in enumerate(inputs)
     ]
     ufo.glyphOrder = ufo.glyphOrder + [g.glyph_name for g in color_glyphs]
     for g in color_glyphs:

--- a/tests/colr_to_svg.py
+++ b/tests/colr_to_svg.py
@@ -53,7 +53,9 @@ def _map_font_emsquare_to_viewbox(upem: int, view_box: Rect) -> Affine2D:
 
 
 def _svg_root(view_box: Rect) -> etree.Element:
-    svg_tree = etree.parse(test_helper.locate_test_file("colr_to_svg_template.svg"))
+    svg_tree = etree.parse(
+        str(test_helper.locate_test_file("colr_to_svg_template.svg"))
+    )
     svg_root = svg_tree.getroot()
     svg_root.attrib["viewBox"] = f"{view_box.x} {view_box.y} {view_box.w} {view_box.h}"
     return svg_root

--- a/tests/minimal_static/config_picosvg.toml
+++ b/tests/minimal_static/config_picosvg.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "picosvg"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/minimal_static/config_untouchedsvg.toml
+++ b/tests/minimal_static/config_untouchedsvg.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "untouchedsvg"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/minimal_static/svg/61.svg
+++ b/tests/minimal_static/svg/61.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 12 12">
 	<path d="M0,0 L0,10 L10,10 L0,0 L0,0 Z"/>
+  	<rect x="2" y="1" width="8" height="0.5" />
+	<ellipse fill="none" cx="3" cy="3" rx="7" ry="4" />
 </svg>

--- a/tests/svg_colr_svg_test.py
+++ b/tests/svg_colr_svg_test.py
@@ -48,8 +48,8 @@ def test_svg_to_colr_to_svg(svg_in, expected_svg_out, color_format, output_forma
         color_format, (svg_in,), output_format
     )
     _, ttfont = write_font._generate_color_font(config, glyph_inputs)
-    svg_before = SVG.parse(test_helper.locate_test_file(svg_in))
+    svg_before = SVG.parse(str(test_helper.locate_test_file(svg_in)))
     svgs_from_font = tuple(colr_to_svg(svg_before.view_box(), ttfont).values())
     assert len(svgs_from_font) == 1
-    svg_expected = SVG.parse(test_helper.locate_test_file(expected_svg_out))
+    svg_expected = SVG.parse(str(test_helper.locate_test_file(expected_svg_out)))
     test_helper.svg_diff(svgs_from_font[0], svg_expected)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -29,8 +29,12 @@ import pytest
 import tempfile
 
 
-def locate_test_file(filename):
-    return os.path.join(os.path.dirname(__file__), filename)
+def test_data_dir() -> Path:
+    return Path(__file__).parent
+
+
+def locate_test_file(filename) -> Path:
+    return test_data_dir() / filename
 
 
 def picosvg(filename, locate=False):
@@ -40,16 +44,14 @@ def picosvg(filename, locate=False):
 
 
 def color_font_config(color_format, svgs, output_format, keep_glyph_names=True):
-    svgs = [locate_test_file(s) for s in svgs]
+    svgs = tuple(locate_test_file(s) for s in svgs)
     fea_file = os.path.join(tempfile.gettempdir(), "test.fea")
-    rgi_seqs = [codepoints.from_filename(f) for f in svgs]
+    rgi_seqs = tuple(codepoints.from_filename(str(f)) for f in svgs)
     with open(fea_file, "w") as f:
         f.write(write_fea._generate_fea(rgi_seqs))
 
     return (
-        config.load(
-            config_file=None, additional_srcs=tuple(Path(s) for s in svgs)
-        )._replace(
+        config.load(config_file=None, additional_srcs=svgs)._replace(
             family="UnitTest",
             color_format=color_format,
             upem=100,


### PR DESCRIPTION
Covers issues encountered trying to update https://github.com/googlefonts/color-fonts using python 3.9, adding tests where possible. Notably we had stopped using picosvgs and untouchedsvg wasn't working very well.

Fixes #196.