### PR TITLE
Use built-in importlib.resources on python >= 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,16 +14,17 @@ cu2qu==1.6.7              # via ufo2ft
 dataclasses==0.8; python_version < '3.7'  # via picosvg
 fonttools[ufo]==4.17.1    # via booleanoperations, cffsubr, compreffor, cu2qu, nanoemoji (setup.py), ufo2ft, ufolib2
 fs==2.4.11                # via fonttools
-importlib-resources==3.3.0  # via cffsubr
+importlib-resources==3.3.0; python_version < '3.9'  # via nanoemoji (setup.py)
 lxml==4.6.1               # via nanoemoji (setup.py), picosvg
 ninja==1.10.0.post2       # via nanoemoji (setup.py)
 picosvg==0.7.2            # via nanoemoji (setup.py)
 pillow==8.0.1             # via nanoemoji (setup.py)
 pyclipper==1.2.0          # via booleanoperations
 pytz==2020.4              # via fs
-regex==2020.11.13          # via nanoemoji (setup.py)
+regex==2020.11.13         # via nanoemoji (setup.py)
 six==1.15.0               # via absl-py, fs
-skia-pathops==0.5.1.post1       # via picosvg
+skia-pathops==0.5.1.post1  # via picosvg
+toml==0.10.2              # via nanoemoji (setup.py)
 typing-extensions==3.7.4.3  # via ufolib2
 ufo2ft[cffsubr]==2.18.1   # via nanoemoji (setup.py)
 ufolib2==0.8.0            # via nanoemoji (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "absl-py>=0.9.0",
         "dataclasses>=0.8; python_version < '3.7'",
         "fonttools[ufo]>=4.17.0",
-        "importlib_resources>=3.3.0",
+        "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
         "picosvg>=0.7.1",

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -14,14 +14,10 @@
 
 from absl import flags
 
-# works even on py39
-import importlib_resources as resources
-
-# does NOT work on py39; resources.path (and .contents) don't admit our resources exist
-# try:
-#     import importlib.resources as resources
-# except ImportError:
-#     import importlib_resources as resources
+try:
+    import importlib.resources as resources
+except ImportError:
+    import importlib_resources as resources
 
 from pathlib import Path
 import toml


### PR DESCRIPTION
Add an empty `__init__.py` to `src/nanoemoji/data` directory to mark it as a proper package, not an implicit namespace package (which built-in `importlib.resources` does not support).

Fixes https://github.com/googlefonts/nanoemoji/issues/198