### PR TITLE
Allow CLI flags to override (default) config

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -16,6 +16,7 @@ from absl import logging
 from itertools import chain, groupby
 from lxml import etree  # type: ignore
 from nanoemoji.colors import Color
+from nanoemoji.config import FontConfig
 from nanoemoji import glyph
 from nanoemoji.paint import (
     Extend,
@@ -32,12 +33,8 @@ from picosvg.svg_reuse import normalize, affine_between
 from picosvg.svg_transform import Affine2D
 from picosvg.svg import SVG
 from picosvg.svg_types import SVGPath, SVGLinearGradient, SVGRadialGradient
-from typing import Generator, NamedTuple, Optional, Sequence, Tuple, TYPE_CHECKING
+from typing import Generator, NamedTuple, Optional, Sequence, Tuple
 import ufoLib2
-
-# avoid circular import
-if TYPE_CHECKING:
-    from nanoemoji.config import FontConfig
 
 
 def _scale_viewbox_to_emsquare(view_box: Rect, upem: int) -> Tuple[float, float]:
@@ -313,7 +310,7 @@ class ColorGlyph(NamedTuple):
 
     @staticmethod
     def create(
-        font_config: "FontConfig",
+        font_config: FontConfig,
         ufo: ufoLib2.Font,
         filename: str,
         glyph_id: int,

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -261,6 +261,12 @@ def _painted_layers(
     reuse_tolerance: float,
     ignore_reuse_error: bool = True,
 ) -> Generator[PaintedLayer, None, None]:
+    if reuse_tolerance < 0:
+        # shape reuse disabled
+        for path in picosvg.shapes():
+            yield PaintedLayer(_paint(debug_hint, upem, picosvg, path), path.d)
+        return
+
     # Don't sort; we only want to find groups that are consecutive in the picosvg
     # to ensure we don't mess up layer order
     for (paint, normalized), paths in groupby(

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl import flags
 from absl import logging
 from itertools import chain, groupby
 from lxml import etree  # type: ignore
 from nanoemoji.colors import Color
-from nanoemoji.config import FontConfig
 from nanoemoji import glyph
 from nanoemoji.paint import (
     Extend,
@@ -34,27 +32,12 @@ from picosvg.svg_reuse import normalize, affine_between
 from picosvg.svg_transform import Affine2D
 from picosvg.svg import SVG
 from picosvg.svg_types import SVGPath, SVGLinearGradient, SVGRadialGradient
-from typing import Generator, NamedTuple, Optional, Sequence, Tuple
+from typing import Generator, NamedTuple, Optional, Sequence, Tuple, TYPE_CHECKING
 import ufoLib2
 
-
-FLAGS = flags.FLAGS
-
-
-flags.DEFINE_float(
-    "reuse_tolerence",
-    0.1,
-    "Allowable difference in reused shape in input coordinates (e.g. svg)."
-    " Normalized shapes snap to whole multiples of tolerance;"
-    " choice of a value where 1/tolerance is an int recommended",
-)
-# https://github.com/googlefonts/picosvg/issues/138
-flags.DEFINE_bool(
-    "ignore_reuse_error",
-    True,
-    "Whether to fail or continue with a warning when picosvg cannot compute "
-    "affine between paths that normalize the same.",
-)
+# avoid circular import
+if TYPE_CHECKING:
+    from nanoemoji.config import FontConfig
 
 
 def _scale_viewbox_to_emsquare(view_box: Rect, upem: int) -> Tuple[float, float]:
@@ -261,30 +244,36 @@ def _paint(debug_hint, upem, picosvg, shape):
 
 
 def _in_glyph_reuse_key(
-    debug_hint: str, upem: int, picosvg: SVG, shape: SVGPath
+    debug_hint: str, upem: int, picosvg: SVG, shape: SVGPath, reuse_tolerance: float
 ) -> Tuple[Paint, SVGPath]:
     """Within a glyph reuse shapes only when painted consistently.
     paint+normalized shape ensures this."""
     return (
         _paint(debug_hint, upem, picosvg, shape),
-        normalize(shape, FLAGS.reuse_tolerence),
+        normalize(shape, reuse_tolerance),
     )
 
 
 def _painted_layers(
-    debug_hint: str, upem: int, picosvg: SVG
+    debug_hint: str,
+    upem: int,
+    picosvg: SVG,
+    reuse_tolerance: float,
+    ignore_reuse_error: bool = True,
 ) -> Generator[PaintedLayer, None, None]:
     # Don't sort; we only want to find groups that are consecutive in the picosvg
     # to ensure we don't mess up layer order
     for (paint, normalized), paths in groupby(
         picosvg.shapes(),
-        key=lambda s: _in_glyph_reuse_key(debug_hint, upem, picosvg, s),
+        key=lambda s: _in_glyph_reuse_key(
+            debug_hint, upem, picosvg, s, reuse_tolerance
+        ),
     ):
         paths = list(paths)
         transforms = ()
         if len(paths) > 1:
             transforms = tuple(
-                affine_between(paths[0], p, FLAGS.reuse_tolerence) for p in paths[1:]
+                affine_between(paths[0], p, reuse_tolerance) for p in paths[1:]
             )
 
         success = True
@@ -295,7 +284,7 @@ def _painted_layers(
                     f"{debug_hint} grouped the following paths but no affine_between "
                     f"could be computed:\n  {paths[0]}\n  {path}"
                 )
-                if FLAGS.ignore_reuse_error:
+                if ignore_reuse_error:
                     logging.warning(error_msg)
                 else:
                     raise ValueError(error_msg)
@@ -318,7 +307,7 @@ class ColorGlyph(NamedTuple):
 
     @staticmethod
     def create(
-        font_config: FontConfig,
+        font_config: "FontConfig",
         ufo: ufoLib2.Font,
         filename: str,
         glyph_id: int,
@@ -337,7 +326,15 @@ class ColorGlyph(NamedTuple):
         # Grab the transform + (color, glyph) layers unless they aren't to be touched
         painted_layers = None
         if font_config.has_picosvgs:
-            painted_layers = tuple(_painted_layers(filename, ufo.info.unitsPerEm, svg))
+            painted_layers = tuple(
+                _painted_layers(
+                    filename,
+                    ufo.info.unitsPerEm,
+                    svg,
+                    font_config.reuse_tolerance,
+                    font_config.ignore_reuse_error,
+                )
+            )
         return ColorGlyph(
             ufo, filename, glyph_name, glyph_id, codepoints, painted_layers, svg
         )

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -23,14 +23,47 @@ from pathlib import Path
 import toml
 from typing import Any, Iterable, MutableMapping, NamedTuple, Optional, Tuple, Sequence
 
+from nanoemoji.write_font import _COLOR_FORMAT_GENERATORS
+
 
 FLAGS = flags.FLAGS
 
 
-_DEFAULT_CONFIG = "_default.toml"
+_DEFAULT_CONFIG_FILE = "_default.toml"
 
-
-flags.DEFINE_string("config", _DEFAULT_CONFIG, "Config file")
+# we use None as a sentinel for flag not set; FontConfig class has the actual defaults.
+# CLI flags override config file (which overrides default FontConfig).
+flags.DEFINE_string("config", None, "Config file")
+flags.DEFINE_integer("upem", None, "Units per em.")
+flags.DEFINE_string("family", None, "Family name.")
+flags.DEFINE_string("output_file", None, "Output filename.")
+flags.DEFINE_enum(
+    "color_format",
+    None,
+    sorted(_COLOR_FORMAT_GENERATORS.keys()),
+    "Type of font to generate.",
+)
+flags.DEFINE_enum(
+    "output", None, ["ufo", "font"], "Whether to output a font binary or a UFO"
+)
+flags.DEFINE_bool(
+    "keep_glyph_names", None, "Whether or not to store glyph names in the font."
+)
+flags.DEFINE_bool("clip_to_viewbox", None, "Whether to clip content outside viewbox")
+flags.DEFINE_float(
+    "reuse_tolerance",
+    None,
+    "Allowable difference in reused shape in input coordinates (e.g. svg)."
+    " Normalized shapes snap to whole multiples of tolerance;"
+    " choice of a value where 1/tolerance is an int recommended",
+)
+# https://github.com/googlefonts/picosvg/issues/138
+flags.DEFINE_bool(
+    "ignore_reuse_error",
+    None,
+    "Whether to fail or continue with a warning when picosvg cannot compute "
+    "affine between paths that normalize the same.",
+)
 
 
 class Axis(NamedTuple):
@@ -58,6 +91,7 @@ class FontConfig(NamedTuple):
     color_format: str = "glyf_colr_1"
     upem: int = 1024
     reuse_tolerance: float = 0.1
+    ignore_reuse_error: bool = True
     keep_glyph_names: bool = False
     clip_to_viewbox: bool = True
     output: str = "font"
@@ -109,8 +143,8 @@ def _resolve_config(
     config_file: Path = None,
 ) -> Tuple[Optional[Path], MutableMapping[str, Any]]:
     if config_file is None:
-        if FLAGS.config == _DEFAULT_CONFIG:
-            with resources.path("nanoemoji.data", _DEFAULT_CONFIG) as config_file:
+        if FLAGS.config is None:
+            with resources.path("nanoemoji.data", _DEFAULT_CONFIG_FILE) as config_file:
                 # no config_dir in this context; bad input if we need it
                 return None, toml.load(config_file)
         else:
@@ -135,20 +169,30 @@ def _resolve_src(relative_base: Optional[Path], src: str) -> Iterable[Path]:
     return (relative_base.joinpath(src_path),)
 
 
+_DEFAULT_CONFIG = FontConfig()
+
+
+def _pop_flag(config: MutableMapping[str, Any], name: str) -> Any:
+    config_value = config.pop(name, None)
+    flag_value = getattr(FLAGS, name)
+    if config_value is None and flag_value is None:
+        return getattr(_DEFAULT_CONFIG, name)
+    return flag_value if flag_value is not None else config_value
+
+
 def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontConfig:
     config_dir, config = _resolve_config(config_file)
-    default_config = FontConfig()
 
-    family = config.pop("family", default_config.family)
-    output_file = config.pop("output_file", default_config.output_file)
-    color_format = config.pop("color_format", default_config.color_format)
-    upem = int(config.pop("upem", default_config.upem))
-    reuse_tolerance = float(
-        config.pop("reuse_tolerance", default_config.reuse_tolerance)
-    )
-    keep_glyph_names = config.pop("keep_glyph_names", default_config.keep_glyph_names)
-    clip_to_viewbox = config.pop("clip_to_viewbox", default_config.clip_to_viewbox)
-    output = config.pop("output", default_config.output)
+    # CLI flags will take precedence over the config file
+    family = _pop_flag(config, "family")
+    output_file = _pop_flag(config, "output_file")
+    color_format = _pop_flag(config, "color_format")
+    upem = int(_pop_flag(config, "upem"))
+    reuse_tolerance = float(_pop_flag(config, "reuse_tolerance"))
+    ignore_reuse_error = _pop_flag(config, "ignore_reuse_error")
+    keep_glyph_names = _pop_flag(config, "keep_glyph_names")
+    clip_to_viewbox = _pop_flag(config, "clip_to_viewbox")
+    output = _pop_flag(config, "output")
 
     axes = []
     for axis_tag, axis_config in config.pop("axis").items():
@@ -213,11 +257,12 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         color_format=color_format,
         upem=upem,
         reuse_tolerance=reuse_tolerance,
+        ignore_reuse_error=ignore_reuse_error,
         keep_glyph_names=keep_glyph_names,
         clip_to_viewbox=clip_to_viewbox,
         output=output,
-        fea_file=default_config.fea_file,
-        codepointmap_file=default_config.codepointmap_file,
+        fea_file=_DEFAULT_CONFIG.fea_file,
+        codepointmap_file=_DEFAULT_CONFIG.codepointmap_file,
         axes=tuple(axes),
         masters=tuple(masters),
         source_names=tuple(sorted(source_names)),

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -67,9 +67,9 @@ flags.DEFINE_bool("clip_to_viewbox", None, "Whether to clip content outside view
 flags.DEFINE_float(
     "reuse_tolerance",
     None,
-    "Allowable difference in reused shape in input coordinates (e.g. svg)."
+    "Allowable absolute difference in reused shape in input coordinates (e.g. svg)."
     " Normalized shapes snap to whole multiples of tolerance;"
-    " choice of a value where 1/tolerance is an int recommended",
+    " A negative value means that shape reuse is disabled.",
 )
 # https://github.com/googlefonts/picosvg/issues/138
 flags.DEFINE_bool(

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -23,13 +23,27 @@ from pathlib import Path
 import toml
 from typing import Any, Iterable, MutableMapping, NamedTuple, Optional, Tuple, Sequence
 
-from nanoemoji import write_font
-
 
 FLAGS = flags.FLAGS
 
 
 _DEFAULT_CONFIG_FILE = "_default.toml"
+# NOTE: this must be kept in sync with nanoemoji.write_font._COLOR_FORMAT_GENERATORS
+_COLOR_FORMATS = [
+    "glyf",
+    "glyf_colr_0",
+    "glyf_colr_1",
+    "cff_colr_0",
+    "cff_colr_1",
+    "cff2_colr_0",
+    "cff2_colr_1",
+    "picosvg",
+    "picosvgz",
+    "untouchedsvg",
+    "untouchedsvgz",
+    "cbdt",
+    "sbix",
+]
 
 # we use None as a sentinel for flag not set; FontConfig class has the actual defaults.
 # CLI flags override config file (which overrides default FontConfig).
@@ -40,7 +54,7 @@ flags.DEFINE_string("output_file", None, "Output filename.")
 flags.DEFINE_enum(
     "color_format",
     None,
-    sorted(write_font._COLOR_FORMAT_GENERATORS.keys()),
+    sorted(_COLOR_FORMATS),
     "Type of font to generate.",
 )
 flags.DEFINE_enum(

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import toml
 from typing import Any, Iterable, MutableMapping, NamedTuple, Optional, Tuple, Sequence
 
-from nanoemoji.write_font import _COLOR_FORMAT_GENERATORS
+from nanoemoji import write_font
 
 
 FLAGS = flags.FLAGS
@@ -40,7 +40,7 @@ flags.DEFINE_string("output_file", None, "Output filename.")
 flags.DEFINE_enum(
     "color_format",
     None,
-    sorted(_COLOR_FORMAT_GENERATORS.keys()),
+    sorted(write_font._COLOR_FORMAT_GENERATORS.keys()),
     "Type of font to generate.",
 )
 flags.DEFINE_enum(

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -25,6 +25,7 @@ from itertools import chain
 from lxml import etree  # pytype: disable=import-error
 from nanoemoji import codepoints, config
 from nanoemoji.colors import Color
+from nanoemoji.config import FontConfig
 from nanoemoji.color_glyph import ColorGlyph, PaintedLayer
 from nanoemoji.glyph import glyph_name
 from nanoemoji.paint import (
@@ -55,14 +56,9 @@ from typing import (
     NamedTuple,
     Sequence,
     Tuple,
-    TYPE_CHECKING,
 )
 from ufoLib2.objects import Component, Glyph
 import ufo2ft
-
-# avoid circular import
-if TYPE_CHECKING:
-    from nanoemoji.config import FontConfig
 
 
 FLAGS = flags.FLAGS
@@ -470,7 +466,7 @@ def _ensure_codepoints_will_have_glyphs(ufo, glyph_inputs):
     ufo.glyphOrder = ufo.glyphOrder + sorted(glyph_names)
 
 
-def _generate_color_font(config: "FontConfig", inputs: Iterable[InputGlyph]):
+def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
     """Make a UFO and optionally a TTFont from svgs."""
     ufo = _ufo(config.family, config.upem, config.keep_glyph_names)
     _ensure_codepoints_will_have_glyphs(ufo, inputs)

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -25,7 +25,6 @@ from itertools import chain
 from lxml import etree  # pytype: disable=import-error
 from nanoemoji import codepoints, config
 from nanoemoji.colors import Color
-from nanoemoji.config import FontConfig
 from nanoemoji.color_glyph import ColorGlyph, PaintedLayer
 from nanoemoji.glyph import glyph_name
 from nanoemoji.paint import (
@@ -56,9 +55,14 @@ from typing import (
     NamedTuple,
     Sequence,
     Tuple,
+    TYPE_CHECKING,
 )
 from ufoLib2.objects import Component, Glyph
 import ufo2ft
+
+# avoid circular import
+if TYPE_CHECKING:
+    from nanoemoji.config import FontConfig
 
 
 FLAGS = flags.FLAGS
@@ -124,13 +128,13 @@ _COLOR_FORMAT_GENERATORS = {
         ".ttf",
     ),
     "cbdt": ColorGenerator(
-        lambda *args: _not_impl("ufo", *args),
-        lambda *args: _not_impl("TTFont", *args),
+        lambda *args: _not_impl("apply_ufo", "cbdt", *args),
+        lambda *args: _not_impl("apply_ttfont", "cbdt", *args),
         ".ttf",
     ),
     "sbix": ColorGenerator(
-        lambda *args: _not_impl("ufo", *args),
-        lambda *args: _not_impl("TTFont", *args),
+        lambda *args: _not_impl("apply_ufo", "sbix", *args),
+        lambda *args: _not_impl("apply_ttfont", "sbix", *args),
         ".ttf",
     ),
 }
@@ -197,8 +201,8 @@ def _write(ufo, ttfont, output_file):
         ttfont.save(output_file)
 
 
-def _not_impl(*_):
-    raise NotImplementedError("%s not implemented" % FLAGS.color_format)
+def _not_impl(func_name, color_format, *_):
+    raise NotImplementedError(f"{func_name} for {color_format} not implemented")
 
 
 def _next_name(ufo: ufoLib2.Font, name_fn) -> str:
@@ -465,7 +469,7 @@ def _ensure_codepoints_will_have_glyphs(ufo, glyph_inputs):
     ufo.glyphOrder = ufo.glyphOrder + sorted(glyph_names)
 
 
-def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
+def _generate_color_font(config: "FontConfig", inputs: Iterable[InputGlyph]):
     """Make a UFO and optionally a TTFont from svgs."""
     ufo = _ufo(config.family, config.upem, config.keep_glyph_names)
     _ensure_codepoints_will_have_glyphs(ufo, inputs)

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -138,6 +138,7 @@ _COLOR_FORMAT_GENERATORS = {
         ".ttf",
     ),
 }
+assert _COLOR_FORMAT_GENERATORS.keys() == set(config._COLOR_FORMATS)
 
 
 def _ufo(family: str, upem: int, keep_glyph_names: bool = False) -> ufoLib2.Font:

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -1,0 +1,538 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".space"/>
+    <GlyphID id="2" name="e000"/>
+    <GlyphID id="3" name="e001"/>
+    <GlyphID id="4" name="e000.0"/>
+    <GlyphID id="5" name="e000.1"/>
+    <GlyphID id="6" name="e000.2"/>
+    <GlyphID id="7" name="e000.3"/>
+    <GlyphID id="8" name="e000.4"/>
+    <GlyphID id="9" name="e000.5"/>
+    <GlyphID id="10" name="e000.6"/>
+    <GlyphID id="11" name="e000.7"/>
+    <GlyphID id="12" name="e000.8"/>
+    <GlyphID id="13" name="e000.9"/>
+    <GlyphID id="14" name="e001.0"/>
+  </GlyphOrder>
+
+  <hmtx>
+    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".space" width="100" lsb="0"/>
+    <mtx name="e000" width="100" lsb="0"/>
+    <mtx name="e000.0" width="100" lsb="3"/>
+    <mtx name="e000.1" width="100" lsb="47"/>
+    <mtx name="e000.2" width="100" lsb="48"/>
+    <mtx name="e000.3" width="100" lsb="45"/>
+    <mtx name="e000.4" width="100" lsb="48"/>
+    <mtx name="e000.5" width="100" lsb="9"/>
+    <mtx name="e000.6" width="100" lsb="47"/>
+    <mtx name="e000.7" width="100" lsb="47"/>
+    <mtx name="e000.8" width="100" lsb="84"/>
+    <mtx name="e000.9" width="100" lsb="3"/>
+    <mtx name="e001" width="100" lsb="0"/>
+    <mtx name="e001.0" width="100" lsb="49"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+      <map code="0xe001" name="e001"/><!-- ???? -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+      <map code="0xe001" name="e001"/><!-- ???? -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name=".space"/><!-- contains no outline data -->
+
+    <TTGlyph name="e000" xMin="0" yMin="0" xMax="100" yMax="100">
+      <contour>
+        <pt x="100" y="100" on="1"/>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.0" xMin="3" yMin="3" xMax="97" yMax="97">
+      <contour>
+        <pt x="3" y="50" on="1"/>
+        <pt x="3" y="40" on="0"/>
+        <pt x="10" y="23" on="0"/>
+        <pt x="23" y="10" on="0"/>
+        <pt x="40" y="3" on="0"/>
+        <pt x="50" y="3" on="1"/>
+        <pt x="60" y="3" on="0"/>
+        <pt x="77" y="10" on="0"/>
+        <pt x="90" y="23" on="0"/>
+        <pt x="97" y="40" on="0"/>
+        <pt x="97" y="50" on="1"/>
+        <pt x="97" y="60" on="0"/>
+        <pt x="90" y="77" on="0"/>
+        <pt x="77" y="90" on="0"/>
+        <pt x="60" y="97" on="0"/>
+        <pt x="50" y="97" on="1"/>
+        <pt x="40" y="97" on="0"/>
+        <pt x="23" y="90" on="0"/>
+        <pt x="10" y="77" on="0"/>
+        <pt x="3" y="60" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.1" xMin="47" yMin="50" xMax="53" yMax="81">
+      <contour>
+        <pt x="50" y="50" on="1"/>
+        <pt x="49" y="50" on="0"/>
+        <pt x="47" y="52" on="0"/>
+        <pt x="47" y="53" on="1"/>
+        <pt x="47" y="78" on="1"/>
+        <pt x="47" y="80" on="0"/>
+        <pt x="49" y="81" on="0"/>
+        <pt x="50" y="81" on="1"/>
+        <pt x="50" y="81" on="1"/>
+        <pt x="51" y="81" on="0"/>
+        <pt x="53" y="80" on="0"/>
+        <pt x="53" y="78" on="1"/>
+        <pt x="53" y="53" on="1"/>
+        <pt x="53" y="52" on="0"/>
+        <pt x="51" y="50" on="0"/>
+        <pt x="50" y="50" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.2" xMin="48" yMin="49" xMax="64" yMax="70">
+      <contour>
+        <pt x="50" y="50" on="1"/>
+        <pt x="49" y="51" on="0"/>
+        <pt x="48" y="53" on="0"/>
+        <pt x="49" y="54" on="1"/>
+        <pt x="58" y="69" on="1"/>
+        <pt x="58" y="70" on="0"/>
+        <pt x="61" y="70" on="0"/>
+        <pt x="62" y="70" on="1"/>
+        <pt x="62" y="69" on="1"/>
+        <pt x="63" y="69" on="0"/>
+        <pt x="64" y="66" on="0"/>
+        <pt x="63" y="65" on="1"/>
+        <pt x="54" y="51" on="1"/>
+        <pt x="53" y="50" on="0"/>
+        <pt x="51" y="49" on="0"/>
+        <pt x="50" y="50" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.3" xMin="45" yMin="45" xMax="55" yMax="55">
+      <contour>
+        <pt x="45" y="50" on="1"/>
+        <pt x="45" y="48" on="0"/>
+        <pt x="48" y="45" on="0"/>
+        <pt x="50" y="45" on="1"/>
+        <pt x="52" y="45" on="0"/>
+        <pt x="55" y="48" on="0"/>
+        <pt x="55" y="50" on="1"/>
+        <pt x="55" y="52" on="0"/>
+        <pt x="52" y="55" on="0"/>
+        <pt x="50" y="55" on="1"/>
+        <pt x="48" y="55" on="0"/>
+        <pt x="45" y="52" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.4" xMin="48" yMin="48" xMax="52" yMax="52">
+      <contour>
+        <pt x="48" y="50" on="1"/>
+        <pt x="48" y="49" on="0"/>
+        <pt x="49" y="48" on="0"/>
+        <pt x="50" y="48" on="1"/>
+        <pt x="51" y="48" on="0"/>
+        <pt x="52" y="49" on="0"/>
+        <pt x="52" y="50" on="1"/>
+        <pt x="52" y="51" on="0"/>
+        <pt x="51" y="52" on="0"/>
+        <pt x="50" y="52" on="1"/>
+        <pt x="49" y="52" on="0"/>
+        <pt x="48" y="51" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.5" xMin="9" yMin="47" xMax="16" yMax="53">
+      <contour>
+        <pt x="9" y="50" on="1"/>
+        <pt x="9" y="49" on="0"/>
+        <pt x="11" y="47" on="0"/>
+        <pt x="12" y="47" on="1"/>
+        <pt x="14" y="47" on="0"/>
+        <pt x="16" y="49" on="0"/>
+        <pt x="16" y="50" on="1"/>
+        <pt x="16" y="51" on="0"/>
+        <pt x="14" y="53" on="0"/>
+        <pt x="12" y="53" on="1"/>
+        <pt x="11" y="53" on="0"/>
+        <pt x="9" y="51" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.6" xMin="47" yMin="84" xMax="53" yMax="91">
+      <contour>
+        <pt x="47" y="87" on="1"/>
+        <pt x="47" y="86" on="0"/>
+        <pt x="49" y="84" on="0"/>
+        <pt x="50" y="84" on="1"/>
+        <pt x="51" y="84" on="0"/>
+        <pt x="53" y="86" on="0"/>
+        <pt x="53" y="87" on="1"/>
+        <pt x="53" y="89" on="0"/>
+        <pt x="51" y="91" on="0"/>
+        <pt x="50" y="91" on="1"/>
+        <pt x="49" y="91" on="0"/>
+        <pt x="47" y="89" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.7" xMin="47" yMin="9" xMax="53" yMax="16">
+      <contour>
+        <pt x="47" y="12" on="1"/>
+        <pt x="47" y="11" on="0"/>
+        <pt x="49" y="9" on="0"/>
+        <pt x="50" y="9" on="1"/>
+        <pt x="51" y="9" on="0"/>
+        <pt x="53" y="11" on="0"/>
+        <pt x="53" y="12" on="1"/>
+        <pt x="53" y="14" on="0"/>
+        <pt x="51" y="16" on="0"/>
+        <pt x="50" y="16" on="1"/>
+        <pt x="49" y="16" on="0"/>
+        <pt x="47" y="14" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.8" xMin="84" yMin="47" xMax="91" yMax="53">
+      <contour>
+        <pt x="84" y="50" on="1"/>
+        <pt x="84" y="49" on="0"/>
+        <pt x="86" y="47" on="0"/>
+        <pt x="87" y="47" on="1"/>
+        <pt x="89" y="47" on="0"/>
+        <pt x="91" y="49" on="0"/>
+        <pt x="91" y="50" on="1"/>
+        <pt x="91" y="51" on="0"/>
+        <pt x="89" y="53" on="0"/>
+        <pt x="87" y="53" on="1"/>
+        <pt x="86" y="53" on="0"/>
+        <pt x="84" y="51" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.9" xMin="3" yMin="3" xMax="97" yMax="97">
+      <contour>
+        <pt x="50" y="94" on="1"/>
+        <pt x="41" y="94" on="0"/>
+        <pt x="25" y="87" on="0"/>
+        <pt x="13" y="75" on="0"/>
+        <pt x="6" y="59" on="0"/>
+        <pt x="6" y="50" on="1"/>
+        <pt x="6" y="41" on="0"/>
+        <pt x="13" y="25" on="0"/>
+        <pt x="25" y="13" on="0"/>
+        <pt x="41" y="6" on="0"/>
+        <pt x="50" y="6" on="1"/>
+        <pt x="59" y="6" on="0"/>
+        <pt x="75" y="13" on="0"/>
+        <pt x="87" y="25" on="0"/>
+        <pt x="94" y="41" on="0"/>
+        <pt x="94" y="50" on="1"/>
+        <pt x="94" y="59" on="0"/>
+        <pt x="87" y="75" on="0"/>
+        <pt x="75" y="87" on="0"/>
+        <pt x="59" y="94" on="0"/>
+      </contour>
+      <contour>
+        <pt x="50" y="97" on="1"/>
+        <pt x="50" y="97" on="1"/>
+        <pt x="60" y="97" on="0"/>
+        <pt x="77" y="90" on="0"/>
+        <pt x="90" y="77" on="0"/>
+        <pt x="97" y="60" on="0"/>
+        <pt x="97" y="50" on="1"/>
+        <pt x="97" y="40" on="0"/>
+        <pt x="90" y="23" on="0"/>
+        <pt x="77" y="10" on="0"/>
+        <pt x="60" y="3" on="0"/>
+        <pt x="50" y="3" on="1"/>
+        <pt x="40" y="3" on="0"/>
+        <pt x="23" y="10" on="0"/>
+        <pt x="10" y="23" on="0"/>
+        <pt x="3" y="40" on="0"/>
+        <pt x="3" y="50" on="1"/>
+        <pt x="3" y="60" on="0"/>
+        <pt x="10" y="77" on="0"/>
+        <pt x="23" y="90" on="0"/>
+        <pt x="40" y="97" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e001" xMin="0" yMin="0" xMax="100" yMax="100">
+      <contour>
+        <pt x="100" y="100" on="1"/>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e001.0" xMin="49" yMin="48" xMax="71" yMax="63">
+      <contour>
+        <pt x="50" y="50" on="1"/>
+        <pt x="49" y="51" on="0"/>
+        <pt x="50" y="54" on="0"/>
+        <pt x="51" y="54" on="1"/>
+        <pt x="66" y="62" on="1"/>
+        <pt x="67" y="63" on="0"/>
+        <pt x="69" y="62" on="0"/>
+        <pt x="70" y="61" on="1"/>
+        <pt x="70" y="61" on="1"/>
+        <pt x="71" y="60" on="0"/>
+        <pt x="70" y="57" on="0"/>
+        <pt x="69" y="57" on="1"/>
+        <pt x="54" y="49" on="1"/>
+        <pt x="53" y="48" on="0"/>
+        <pt x="51" y="49" on="0"/>
+        <pt x="50" y="50" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphV1List>
+      <!-- BaseGlyphCount=2 -->
+      <BaseGlyphV1Record index="0">
+        <BaseGlyph value="e000"/>
+        <Paint Format="1"><!-- PaintColrLayers -->
+          <NumLayers value="10"/>
+          <FirstLayerIndex value="0"/>
+        </Paint>
+      </BaseGlyphV1Record>
+      <BaseGlyphV1Record index="1">
+        <BaseGlyph value="e001"/>
+        <Paint Format="1"><!-- PaintColrLayers -->
+          <NumLayers value="4"/>
+          <FirstLayerIndex value="10"/>
+        </Paint>
+      </BaseGlyphV1Record>
+    </BaseGlyphV1List>
+    <LayerV1List>
+      <!-- LayerCount=14 -->
+      <Paint index="0" Format="5"><!-- PaintGlyph -->
+        <Paint Format="3"><!-- PaintLinearGradient -->
+          <ColorLine>
+            <Extend value="pad"/>
+            <!-- StopCount=2 -->
+            <ColorStop index="0">
+              <StopOffset value="0.3212"/>
+              <Color>
+                <PaletteIndex value="6"/>
+                <Alpha value="1.0"/>
+              </Color>
+            </ColorStop>
+            <ColorStop index="1">
+              <StopOffset value="1.0"/>
+              <Color>
+                <PaletteIndex value="5"/>
+                <Alpha value="1.0"/>
+              </Color>
+            </ColorStop>
+          </ColorLine>
+          <x0 value="50"/>
+          <y0 value="85"/>
+          <x1 value="50"/>
+          <y1 value="13"/>
+          <x2 value="50"/>
+          <y2 value="13"/>
+        </Paint>
+        <Glyph value="e000.0"/>
+      </Paint>
+      <Paint index="1" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="0"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.1"/>
+      </Paint>
+      <Paint index="2" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="1"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.2"/>
+      </Paint>
+      <Paint index="3" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="2"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.3"/>
+      </Paint>
+      <Paint index="4" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="8"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.4"/>
+      </Paint>
+      <Paint index="5" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="3"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.5"/>
+      </Paint>
+      <Paint index="6" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="3"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.6"/>
+      </Paint>
+      <Paint index="7" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="3"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.7"/>
+      </Paint>
+      <Paint index="8" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="3"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.8"/>
+      </Paint>
+      <Paint index="9" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="2"/>
+            <Alpha value="0.2"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.9"/>
+      </Paint>
+      <Paint index="10" Format="5"><!-- PaintGlyph -->
+        <Paint Format="3"><!-- PaintLinearGradient -->
+          <ColorLine>
+            <Extend value="pad"/>
+            <!-- StopCount=2 -->
+            <ColorStop index="0">
+              <StopOffset value="0.3212"/>
+              <Color>
+                <PaletteIndex value="6"/>
+                <Alpha value="1.0"/>
+              </Color>
+            </ColorStop>
+            <ColorStop index="1">
+              <StopOffset value="1.0"/>
+              <Color>
+                <PaletteIndex value="5"/>
+                <Alpha value="1.0"/>
+              </Color>
+            </ColorStop>
+          </ColorLine>
+          <x0 value="50"/>
+          <y0 value="85"/>
+          <x1 value="50"/>
+          <y1 value="13"/>
+          <x2 value="50"/>
+          <y2 value="13"/>
+        </Paint>
+        <Glyph value="e000.0"/>
+      </Paint>
+      <Paint index="11" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="4"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e000.1"/>
+      </Paint>
+      <Paint index="12" Format="5"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <Color>
+            <PaletteIndex value="7"/>
+            <Alpha value="1.0"/>
+          </Color>
+        </Paint>
+        <Glyph value="e001.0"/>
+      </Paint>
+      <Paint index="13" Format="1"><!-- PaintColrLayers -->
+        <NumLayers value="7"/>
+        <FirstLayerIndex value="3"/>
+      </Paint>
+    </LayerV1List>
+  </COLR>
+
+  <CPAL>
+    <version value="0"/>
+    <numPaletteEntries value="9"/>
+    <palette index="0">
+      <color index="0" value="#0000FFFF"/>
+      <color index="1" value="#008000FF"/>
+      <color index="2" value="#424242FF"/>
+      <color index="3" value="#757575FF"/>
+      <color index="4" value="#800080FF"/>
+      <color index="5" value="#B0BEC5FF"/>
+      <color index="6" value="#ECEFF1FF"/>
+      <color index="7" value="#FF0000FF"/>
+      <color index="8" value="#FFFFFFFF"/>
+    </palette>
+  </CPAL>
+
+</ttFont>

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -93,6 +93,12 @@ def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
             "clocks_picosvg.ttx",
             {"color_format": "picosvg"},
         ),
+        # passing a tiny --reuse_tolerance effectively disables shape reuse
+        (
+            ("one-o-clock.svg", "two-o-clock.svg"),
+            "clocks_colr_1_noreuse.ttx",
+            {"color_format": "glyf_colr_1", "reuse_tolerance": 1e-17},
+        ),
         # clocks share shapes, rects share shapes. Should be two distinct svgs in font.
         # glyph order must reshuffle to group correctly
         (

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -93,11 +93,11 @@ def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
             "clocks_picosvg.ttx",
             {"color_format": "picosvg"},
         ),
-        # passing a tiny --reuse_tolerance effectively disables shape reuse
+        # passing a negative --reuse_tolerance disables shape reuse
         (
             ("one-o-clock.svg", "two-o-clock.svg"),
             "clocks_colr_1_noreuse.ttx",
-            {"color_format": "glyf_colr_1", "reuse_tolerance": 1e-17},
+            {"color_format": "glyf_colr_1", "reuse_tolerance": -1},
         ),
         # clocks share shapes, rects share shapes. Should be two distinct svgs in font.
         # glyph order must reshuffle to group correctly


### PR DESCRIPTION
Fixes #220 

Also fixes use of misspelled `--reuse_tolerence` (while the config's `reuse_tolerance` was being ignored).

A negative value to `--reuse_tolerance` option means completely disabling in-glyph shape reuse.