### PR TITLE
Fix --ignore_reuse_error

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -131,6 +131,7 @@ def write(dest: Path, config: FontConfig):
         "color_format": config.color_format,
         "upem": config.upem,
         "reuse_tolerance": config.reuse_tolerance,
+        "ignore_reuse_error": config.ignore_reuse_error,
         "keep_glyph_names": config.keep_glyph_names,
         "clip_to_viewbox": config.clip_to_viewbox,
         "output": config.output,

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -107,9 +107,7 @@ def write_preamble(nw, font_config: FontConfig):
     def write_font_rule(rule_name, config):
         module_rule(
             "write_font",
-            f" --config {config}"
-            + " -v 1"
-            + " @$out.rsp",
+            f" --config {config}" + " -v 1" + " @$out.rsp",
             rspfile="$out.rsp",
             rspfile_content="$in",
             rule_name=rule_name,

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -108,7 +108,6 @@ def write_preamble(nw, font_config: FontConfig):
         module_rule(
             "write_font",
             f" --config {config}"
-            + _bool_flag("ignore_reuse_error", _get_bool_flag("ignore_reuse_error"))
             + " -v 1"
             + " @$out.rsp",
             rspfile="$out.rsp",


### PR DESCRIPTION
Make it consistent with other config flags; seems to be causing my color-fonts updates to fail because nanoemoji helpfully passes --noignore_reuse_errors along when the flag isn't specified.