### PR TITLE
Utility to count overhead due to variation indices

### DIFF
--- a/src/nanoemoji/colr_traverse.py
+++ b/src/nanoemoji/colr_traverse.py
@@ -1,0 +1,77 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helps with traversal of a COLR glyph graph."""
+
+
+from fontTools.ttLib.tables import otTables as ot
+
+
+_LEAVES = {
+    ot.Paint.Format.PaintSolid,
+    ot.Paint.Format.PaintLinearGradient,
+    ot.Paint.Format.PaintRadialGradient,
+    #ot.Paint.Format.PaintSweepGradient,
+}
+
+_HAS_PAINT = {
+    ot.Paint.Format.PaintGlyph,
+    ot.Paint.Format.PaintTransform,
+    ot.Paint.Format.PaintTranslate,
+    ot.Paint.Format.PaintRotate,
+    ot.Paint.Format.PaintSkew,
+}
+
+
+def _only(seq):
+    seq = tuple(seq)
+    if len(seq) != 1:
+        raise ValueError(f"Need 1 entry, got {len(seq)}")
+    return seq[0]
+
+
+def _base_glyphs(colr, filter_fn):
+    for base_glyph in colr.table.BaseGlyphV1List.BaseGlyphV1Record:
+        if filter_fn(base_glyph):
+            yield base_glyph
+
+
+def _children(colr, paint: ot.Paint):
+    if paint.Format in _LEAVES:
+        return []
+
+    if paint.Format == ot.Paint.Format.PaintColrLayers:
+        return colr.table.LayerV1List.Paint[
+            paint.FirstLayerIndex : paint.FirstLayerIndex + paint.NumLayers
+        ]
+
+    if paint.Format == ot.Paint.Format.PaintColrGlyph:
+        return [_only(_base_glyphs(colr, lambda g: g.BaseGlyph == paint.Glyph)).Paint]
+
+    if paint.Format in _HAS_PAINT:
+        return [paint.Paint]
+
+    if paint.Format == ot.Paint.Format.PaintComposite:
+        return [paint.SourcePaint, paint.BackdropPaint]
+
+    raise ValueError(f"Unrecognized format {paint.Format}")
+
+
+def traverse(colr, root: ot.Paint, callback_fn):
+    frontier = [root]
+    while frontier:
+        current = frontier.pop(0)
+        callback_fn(current)
+
+        frontier.extend(_children(colr, current))

--- a/src/nanoemoji/vf_overhead.py
+++ b/src/nanoemoji/vf_overhead.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helps estimate overhead due to VF offsets."""
+
+from absl import app
+from fontTools.colorLib.builder import LayerV1ListBuilder
+from fontTools import ttLib
+from fontTools.ttLib.tables import otTables as ot
+from nanoemoji import colr_traverse
+from pathlib import Path
+
+# VarIdx costs 4 bytes in every Var<something>
+# ColorIndex costs 4: alpha
+# ColorStop costs 8: 4 (stopOffset) + 4 (ColorIndex)
+# ColorLine costs #stops * 8 : ColorStop
+# Affine2x3 costs 24: 4 per field
+def _overhead_color_line(color_line):
+    return 8 * len(color_line.ColorStop)
+
+def _overhead_gradient(color_line, num_fields):
+    return _overhead_color_line(color_line) + 4 * num_fields
+
+_OVERHEAD = {
+    ot.Paint.Format.PaintColrLayers: lambda p: 0,
+
+    ot.Paint.Format.PaintSolid: lambda p: 4,
+    ot.Paint.Format.PaintLinearGradient: lambda p: _overhead_gradient(p.ColorLine, 6),
+    ot.Paint.Format.PaintRadialGradient: lambda p: _overhead_gradient(p.ColorLine, 6),
+
+    ot.Paint.Format.PaintGlyph: lambda p: 0,
+    ot.Paint.Format.PaintColrGlyph: lambda p: 0,
+
+    ot.Paint.Format.PaintTransform: lambda p: 6 * 4,
+    ot.Paint.Format.PaintTranslate: lambda p: 2 * 4,
+    ot.Paint.Format.PaintRotate: lambda p: 3 * 4,
+    ot.Paint.Format.PaintSkew: lambda p: 4 * 4,
+    ot.Paint.Format.PaintComposite: lambda p: 0,
+}
+
+
+def _count_overhead(colr):
+    total_overhead = 0
+    visited = set()
+    list_builder = LayerV1ListBuilder()
+
+    def _callback(paint):
+        overhead = 0
+        paint_tuple = list_builder._paint_tuple(paint)
+        seen = paint_tuple in visited
+        if not seen:
+            visited.add(paint_tuple)
+            overhead = _OVERHEAD[paint.Format](paint)
+        nonlocal total_overhead
+        total_overhead += overhead
+
+    for base_glyph in colr.table.BaseGlyphV1List.BaseGlyphV1Record:
+        colr_traverse.traverse(colr, base_glyph.Paint, _callback)
+
+    return total_overhead
+
+
+def main(argv):
+    if len(argv) != 2:
+        raise ValueError("Only expected non-flag is font file")
+    font = ttLib.TTFont(argv[1])
+
+    file_size = Path(argv[1]).stat().st_size
+    colr_size = len(font.reader["COLR"])
+    varidx_size = _count_overhead(font["COLR"])
+    pct_colr = 100. * varidx_size / colr_size
+    pct_file = 100. * varidx_size / file_size
+
+    print(f"{varidx_size} / {colr_size} bytes ({pct_colr:.1f}%) of the COLR table are variation indices")
+    print(f"{varidx_size} / {file_size} bytes ({pct_file:.1f}%) of the font file are variation indices")
+
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/src/nanoemoji/write_glyphgraph.py
+++ b/src/nanoemoji/write_glyphgraph.py
@@ -20,11 +20,13 @@ from absl import app
 from absl import flags
 from absl import logging
 from collections import Counter
+from fontTools import colorLib
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables as ot
 from graphviz import Digraph  # pytype: disable=import-error
 from lxml import etree  # pytype: disable=import-error
 from nanoemoji.colors import Color
+from nanoemoji import colr_traverse
 from typing import Mapping, NamedTuple, Set, Tuple
 
 
@@ -73,19 +75,6 @@ class DAG:
             self.graph.edge(src, dest)
         self.edges.add((src, dest))
         return new_edge
-
-
-def _base_glyphs(font, filter_fn):
-    for base_glyph in font["COLR"].table.BaseGlyphV1List.BaseGlyphV1Record:
-        if filter_fn(base_glyph):
-            yield base_glyph
-
-
-def _only(seq):
-    seq = tuple(seq)
-    if len(seq) != 1:
-        raise ValueError(f"Need 1 entry, got {len(seq)}")
-    return seq[0]
 
 
 def _indent(depth):
@@ -236,7 +225,7 @@ def main(argv):
 
     dag = DAG()
 
-    for base_glyph in _base_glyphs(font, lambda _: True):
+    for base_glyph in _base_glyphs(font["COLR"], lambda _: True):
         _glyph(dag, None, font, base_glyph)
 
     print("Count by type")


### PR DESCRIPTION
We've talked from time to time about overhead due to making *everything* variable. Raph and Just also raised this. First draft of a utility to count. 

Sample result:

```shell
$ python -m nanoemoji.vf_overhead ../color-fonts/fonts/noto-glyf_colr_1.ttf
633476 / 1340960 bytes (47.2%) of the COLR table are variation indices
633476 / 3784340 bytes (16.7%) of the font file are variation indices

$ python -m nanoemoji.vf_overhead ../color-fonts/fonts/noto-cff_colr_1.otf 
631884 / 1340254 bytes (47.1%) of the COLR table are variation indices
631884 / 3416684 bytes (18.5%) of the font file are variation indices
```

Should check impact on woff2 as well (ty @drott for the reminder). Edit: did check, see https://github.com/googlefonts/colr-gradients-spec/issues/233 for better numbers (actually built font with/without varidx).