### PR TITLE
renumber Paint format numbers in tests, rename Paint.Format=>PaintFormat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "absl-py>=0.9.0",
         "dataclasses>=0.8; python_version < '3.7'",
-        "fonttools[ufo]>=4.19.0",
+        "fonttools[ufo]>=4.20.0",
         "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -92,23 +92,27 @@ class PaintSolid(Paint):
 
     def to_ufo_paint(self, colors):
         return {
-            "format": self.format,
-            "paletteIndex": colors.index(self.color.opaque()),
-            "alpha": self.color.alpha,
+            "Format": self.format,
+            "Color": {
+                "PaletteIndex": colors.index(self.color.opaque()),
+                "Alpha": self.color.alpha,
+            },
         }
 
 
 def _ufoColorLine(gradient, colors):
     return {
-        "stops": [
+        "ColorStop": [
             {
-                "offset": stop.stopOffset,
-                "paletteIndex": colors.index(stop.color.opaque()),
-                "alpha": stop.color.alpha,
+                "StopOffset": stop.stopOffset,
+                "Color": {
+                    "PaletteIndex": colors.index(stop.color.opaque()),
+                    "Alpha": stop.color.alpha,
+                },
             }
             for stop in gradient.stops
         ],
-        "extend": gradient.extend.name.lower(),
+        "Extend": gradient.extend.name.lower(),
     }
 
 
@@ -133,11 +137,14 @@ class PaintLinearGradient(Paint):
 
     def to_ufo_paint(self, colors):
         return {
-            "format": self.format,
-            "colorLine": _ufoColorLine(self, colors),
-            "p0": self.p0,
-            "p1": self.p1,
-            "p2": self.p2,
+            "Format": self.format,
+            "ColorLine": _ufoColorLine(self, colors),
+            "x0": self.p0[0],
+            "y0": self.p0[1],
+            "x1": self.p1[0],
+            "y1": self.p1[1],
+            "x2": self.p2[0],
+            "y2": self.p2[1],
         }
 
 
@@ -157,11 +164,13 @@ class PaintRadialGradient(Paint):
 
     def to_ufo_paint(self, colors):
         paint = {
-            "format": self.format,
-            "colorLine": _ufoColorLine(self, colors),
-            "c0": self.c0,
-            "c1": self.c1,
+            "Format": self.format,
+            "ColorLine": _ufoColorLine(self, colors),
+            "x0": self.c0[0],
+            "y0": self.c0[1],
             "r0": self.r0,
+            "x1": self.c1[0],
+            "y1": self.c1[1],
             "r1": self.r1,
         }
         return paint
@@ -178,9 +187,9 @@ class PaintGlyph(Paint):
 
     def to_ufo_paint(self, colors):
         paint = {
-            "format": self.format,
-            "glyph": self.glyph,
-            "paint": self.paint.to_ufo_paint(colors),
+            "Format": self.format,
+            "Glyph": self.glyph,
+            "Paint": self.paint.to_ufo_paint(colors),
         }
         return paint
 
@@ -191,7 +200,7 @@ class PaintColrGlyph(Paint):
     glyph: str
 
     def to_ufo_paint(self, _):
-        paint = {"format": self.format, "glyph": self.glyph}
+        paint = {"Format": self.format, "Glyph": self.glyph}
         return paint
 
 
@@ -206,9 +215,9 @@ class PaintTransform(Paint):
 
     def to_ufo_paint(self, colors):
         paint = {
-            "format": self.format,
-            "transform": self.transform,
-            "paint": self.paint.to_ufo_paint(colors),
+            "Format": self.format,
+            "Transform": self.transform,
+            "Paint": self.paint.to_ufo_paint(colors),
         }
         return paint
 
@@ -226,9 +235,9 @@ class PaintComposite(Paint):
 
     def to_ufo_paint(self, colors):
         paint = {
-            "format": self.format,
-            "mode": self.mode.name.lower(),
-            "source": self.source.to_ufo_paint(colors),
-            "backdrop": self.backdrop.to_ufo_paint(colors),
+            "Format": self.format,
+            "CompositeMode": self.mode.name.lower(),
+            "SourcePaint": self.source.to_ufo_paint(colors),
+            "BackdropPaint": self.backdrop.to_ufo_paint(colors),
         }
         return paint

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -79,12 +79,12 @@ class Paint:
 
 @dataclasses.dataclass(frozen=True)
 class PaintColrLayers(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintColrLayers)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintColrLayers)
 
 
 @dataclasses.dataclass(frozen=True)
 class PaintSolid(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintSolid)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintSolid)
     color: Color = css_color("black")
 
     def colors(self):
@@ -114,7 +114,7 @@ def _ufoColorLine(gradient, colors):
 
 @dataclasses.dataclass(frozen=True)
 class PaintLinearGradient(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintLinearGradient)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintLinearGradient)
     extend: Extend = Extend.PAD
     stops: Tuple[ColorStop, ...] = tuple()
     p0: Point = Point()
@@ -143,7 +143,7 @@ class PaintLinearGradient(Paint):
 
 @dataclasses.dataclass(frozen=True)
 class PaintRadialGradient(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintRadialGradient)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintRadialGradient)
     extend: Extend = Extend.PAD
     stops: Tuple[ColorStop] = tuple()
     c0: Point = Point()
@@ -169,7 +169,7 @@ class PaintRadialGradient(Paint):
 
 @dataclasses.dataclass(frozen=True)
 class PaintGlyph(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintGlyph)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintGlyph)
     glyph: str
     paint: Paint
 
@@ -187,7 +187,7 @@ class PaintGlyph(Paint):
 
 @dataclasses.dataclass(frozen=True)
 class PaintColrGlyph(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintColrGlyph)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintColrGlyph)
     glyph: str
 
     def to_ufo_paint(self, _):
@@ -197,7 +197,7 @@ class PaintColrGlyph(Paint):
 
 @dataclasses.dataclass(frozen=True)
 class PaintTransform(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintTransform)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintTransform)
     transform: Tuple[float, float, float, float, float, float]
     paint: Paint
 
@@ -215,7 +215,7 @@ class PaintTransform(Paint):
 
 @dataclasses.dataclass(frozen=True)
 class PaintComposite(Paint):
-    format: ClassVar[int] = int(ot.Paint.Format.PaintComposite)
+    format: ClassVar[int] = int(ot.PaintFormat.PaintComposite)
     mode: CompositeMode
     source: Paint
     backdrop: Paint

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -21,6 +21,7 @@ from absl import logging
 from collections import defaultdict
 import csv
 from fontTools import ttLib
+from fontTools.ttLib.tables import otTables as ot
 from itertools import chain
 from lxml import etree  # pytype: disable=import-error
 from nanoemoji import codepoints, config
@@ -358,6 +359,12 @@ def _ufo_colr_layers(colr_version, colors, color_glyph, glyph_cache):
         layer = _colr_layer(colr_version, glyph.name, painted_layer.paint, colors)
 
         colr_layers.append(layer)
+
+    if colr_version > 0:
+        colr_layers = {
+            "Format": int(ot.PaintFormat.PaintColrLayers),
+            "Layers": colr_layers,
+        }
 
     return colr_layers
 

--- a/tests/clocks_colr_1.ttx
+++ b/tests/clocks_colr_1.ttx
@@ -304,7 +304,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=11 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="3"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
@@ -333,7 +333,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -342,7 +342,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="5"><!-- PaintGlyph -->
+      <Paint index="2" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -351,7 +351,7 @@
         </Paint>
         <Glyph value="e000.2"/>
       </Paint>
-      <Paint index="3" Format="5"><!-- PaintGlyph -->
+      <Paint index="3" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -360,7 +360,7 @@
         </Paint>
         <Glyph value="e000.3"/>
       </Paint>
-      <Paint index="4" Format="5"><!-- PaintGlyph -->
+      <Paint index="4" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="8"/>
@@ -369,7 +369,7 @@
         </Paint>
         <Glyph value="e000.4"/>
       </Paint>
-      <Paint index="5" Format="5"><!-- PaintGlyph -->
+      <Paint index="5" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -378,7 +378,7 @@
         </Paint>
         <Glyph value="e000.5"/>
       </Paint>
-      <Paint index="6" Format="5"><!-- PaintGlyph -->
+      <Paint index="6" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -387,7 +387,7 @@
         </Paint>
         <Glyph value="e000.6"/>
       </Paint>
-      <Paint index="7" Format="5"><!-- PaintGlyph -->
+      <Paint index="7" Format="6"><!-- PaintGlyph -->
         <Paint Format="3"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
@@ -416,7 +416,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="8" Format="5"><!-- PaintGlyph -->
+      <Paint index="8" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="4"/>
@@ -425,7 +425,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="9" Format="5"><!-- PaintGlyph -->
+      <Paint index="9" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="7"/>

--- a/tests/clocks_colr_1.ttx
+++ b/tests/clocks_colr_1.ttx
@@ -304,8 +304,8 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=11 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
-        <Paint Format="3"><!-- PaintLinearGradient -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
+        <Paint Format="4"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
             <!-- StopCount=2 -->
@@ -333,7 +333,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -342,7 +342,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="6"><!-- PaintGlyph -->
+      <Paint index="2" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -351,7 +351,7 @@
         </Paint>
         <Glyph value="e000.2"/>
       </Paint>
-      <Paint index="3" Format="6"><!-- PaintGlyph -->
+      <Paint index="3" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -360,7 +360,7 @@
         </Paint>
         <Glyph value="e000.3"/>
       </Paint>
-      <Paint index="4" Format="6"><!-- PaintGlyph -->
+      <Paint index="4" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="8"/>
@@ -369,7 +369,7 @@
         </Paint>
         <Glyph value="e000.4"/>
       </Paint>
-      <Paint index="5" Format="6"><!-- PaintGlyph -->
+      <Paint index="5" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -378,7 +378,7 @@
         </Paint>
         <Glyph value="e000.5"/>
       </Paint>
-      <Paint index="6" Format="6"><!-- PaintGlyph -->
+      <Paint index="6" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -387,8 +387,8 @@
         </Paint>
         <Glyph value="e000.6"/>
       </Paint>
-      <Paint index="7" Format="6"><!-- PaintGlyph -->
-        <Paint Format="3"><!-- PaintLinearGradient -->
+      <Paint index="7" Format="10"><!-- PaintGlyph -->
+        <Paint Format="4"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
             <!-- StopCount=2 -->
@@ -416,7 +416,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="8" Format="6"><!-- PaintGlyph -->
+      <Paint index="8" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="4"/>
@@ -425,7 +425,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="9" Format="6"><!-- PaintGlyph -->
+      <Paint index="9" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="7"/>

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -355,7 +355,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=14 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="3"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
@@ -384,7 +384,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -393,7 +393,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="5"><!-- PaintGlyph -->
+      <Paint index="2" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -402,7 +402,7 @@
         </Paint>
         <Glyph value="e000.2"/>
       </Paint>
-      <Paint index="3" Format="5"><!-- PaintGlyph -->
+      <Paint index="3" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -411,7 +411,7 @@
         </Paint>
         <Glyph value="e000.3"/>
       </Paint>
-      <Paint index="4" Format="5"><!-- PaintGlyph -->
+      <Paint index="4" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="8"/>
@@ -420,7 +420,7 @@
         </Paint>
         <Glyph value="e000.4"/>
       </Paint>
-      <Paint index="5" Format="5"><!-- PaintGlyph -->
+      <Paint index="5" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -429,7 +429,7 @@
         </Paint>
         <Glyph value="e000.5"/>
       </Paint>
-      <Paint index="6" Format="5"><!-- PaintGlyph -->
+      <Paint index="6" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -438,7 +438,7 @@
         </Paint>
         <Glyph value="e000.6"/>
       </Paint>
-      <Paint index="7" Format="5"><!-- PaintGlyph -->
+      <Paint index="7" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -447,7 +447,7 @@
         </Paint>
         <Glyph value="e000.7"/>
       </Paint>
-      <Paint index="8" Format="5"><!-- PaintGlyph -->
+      <Paint index="8" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -456,7 +456,7 @@
         </Paint>
         <Glyph value="e000.8"/>
       </Paint>
-      <Paint index="9" Format="5"><!-- PaintGlyph -->
+      <Paint index="9" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -465,7 +465,7 @@
         </Paint>
         <Glyph value="e000.9"/>
       </Paint>
-      <Paint index="10" Format="5"><!-- PaintGlyph -->
+      <Paint index="10" Format="6"><!-- PaintGlyph -->
         <Paint Format="3"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
@@ -494,7 +494,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="11" Format="5"><!-- PaintGlyph -->
+      <Paint index="11" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="4"/>
@@ -503,7 +503,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="12" Format="5"><!-- PaintGlyph -->
+      <Paint index="12" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="7"/>

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -384,7 +384,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -393,7 +393,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="6"><!-- PaintGlyph -->
+      <Paint index="2" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -402,7 +402,7 @@
         </Paint>
         <Glyph value="e000.2"/>
       </Paint>
-      <Paint index="3" Format="6"><!-- PaintGlyph -->
+      <Paint index="3" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -411,7 +411,7 @@
         </Paint>
         <Glyph value="e000.3"/>
       </Paint>
-      <Paint index="4" Format="6"><!-- PaintGlyph -->
+      <Paint index="4" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="8"/>
@@ -420,7 +420,7 @@
         </Paint>
         <Glyph value="e000.4"/>
       </Paint>
-      <Paint index="5" Format="6"><!-- PaintGlyph -->
+      <Paint index="5" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -429,7 +429,7 @@
         </Paint>
         <Glyph value="e000.5"/>
       </Paint>
-      <Paint index="6" Format="6"><!-- PaintGlyph -->
+      <Paint index="6" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -438,7 +438,7 @@
         </Paint>
         <Glyph value="e000.6"/>
       </Paint>
-      <Paint index="7" Format="6"><!-- PaintGlyph -->
+      <Paint index="7" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -447,7 +447,7 @@
         </Paint>
         <Glyph value="e000.7"/>
       </Paint>
-      <Paint index="8" Format="6"><!-- PaintGlyph -->
+      <Paint index="8" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="3"/>
@@ -456,7 +456,7 @@
         </Paint>
         <Glyph value="e000.8"/>
       </Paint>
-      <Paint index="9" Format="6"><!-- PaintGlyph -->
+      <Paint index="9" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -465,8 +465,8 @@
         </Paint>
         <Glyph value="e000.9"/>
       </Paint>
-      <Paint index="10" Format="6"><!-- PaintGlyph -->
-        <Paint Format="3"><!-- PaintLinearGradient -->
+      <Paint index="10" Format="10"><!-- PaintGlyph -->
+        <Paint Format="4"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
             <!-- StopCount=2 -->
@@ -494,7 +494,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="11" Format="6"><!-- PaintGlyph -->
+      <Paint index="11" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="4"/>
@@ -503,7 +503,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="12" Format="6"><!-- PaintGlyph -->
+      <Paint index="12" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="7"/>

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -355,8 +355,8 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=14 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
-        <Paint Format="3"><!-- PaintLinearGradient -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
+        <Paint Format="4"><!-- PaintLinearGradient -->
           <ColorLine>
             <Extend value="pad"/>
             <!-- StopCount=2 -->

--- a/tests/colr_to_svg.py
+++ b/tests/colr_to_svg.py
@@ -91,28 +91,28 @@ def _color(ttfont: ttLib.TTFont, palette_index, alpha=1.0) -> colors.Color:
 def _gradient_paint(ttfont: ttLib.TTFont, ot_paint: otTables.Paint) -> _GradientPaint:
     stops = [
         ColorStop(
-            stop.StopOffset.value,
-            _color(ttfont, stop.Color.PaletteIndex, stop.Color.Alpha.value),
+            stop.StopOffset,
+            _color(ttfont, stop.Color.PaletteIndex, stop.Color.Alpha),
         )
         for stop in ot_paint.ColorLine.ColorStop
     ]
-    extend = Extend((ot_paint.ColorLine.Extend.value,))
+    extend = Extend((ot_paint.ColorLine.Extend,))
     if ot_paint.Format == PaintLinearGradient.format:
         return PaintLinearGradient(
             stops=stops,
             extend=extend,
-            p0=Point(ot_paint.x0.value, ot_paint.y0.value),
-            p1=Point(ot_paint.x1.value, ot_paint.y1.value),
-            p2=Point(ot_paint.x2.value, ot_paint.y2.value),
+            p0=Point(ot_paint.x0, ot_paint.y0),
+            p1=Point(ot_paint.x1, ot_paint.y1),
+            p2=Point(ot_paint.x2, ot_paint.y2),
         )
     elif ot_paint.Format == PaintRadialGradient.format:
         return PaintRadialGradient(
             stops=stops,
             extend=extend,
-            c0=Point(ot_paint.x0.value, ot_paint.y0.value),
-            c1=Point(ot_paint.x1.value, ot_paint.y1.value),
-            r0=ot_paint.r0.value,
-            r1=ot_paint.r1.value,
+            c0=Point(ot_paint.x0, ot_paint.y0),
+            c1=Point(ot_paint.x1, ot_paint.y1),
+            r0=ot_paint.r0,
+            r1=ot_paint.r1,
         )
     else:
         raise ValueError(
@@ -126,7 +126,7 @@ def _apply_solid_ot_paint(
     ttfont: ttLib.TTFont,
     ot_paint: otTables.Paint,
 ):
-    color = _color(ttfont, ot_paint.Color.PaletteIndex, ot_paint.Color.Alpha.value)
+    color = _color(ttfont, ot_paint.Color.PaletteIndex, ot_paint.Color.Alpha)
     _apply_solid_paint(svg_path, PaintSolid(color))
 
 
@@ -208,12 +208,12 @@ def _colr_v1_paint_to_svg(
                 Affine2D.identity()
                 if not ot_paint.Transform
                 else Affine2D(
-                    ot_paint.Transform.xx.value,
-                    ot_paint.Transform.yx.value,
-                    ot_paint.Transform.xy.value,
-                    ot_paint.Transform.yy.value,
-                    ot_paint.Transform.dx.value,
-                    ot_paint.Transform.dy.value,
+                    ot_paint.Transform.xx,
+                    ot_paint.Transform.yx,
+                    ot_paint.Transform.xy,
+                    ot_paint.Transform.yy,
+                    ot_paint.Transform.dx,
+                    ot_paint.Transform.dy,
                 )
             ),
             transform,

--- a/tests/linear_gradient_rect_colr_1.ttx
+++ b/tests/linear_gradient_rect_colr_1.ttx
@@ -69,8 +69,8 @@
       <!-- BaseGlyphCount=1 -->
       <BaseGlyphV1Record index="0">
         <BaseGlyph value="e000"/>
-        <Paint Format="6"><!-- PaintGlyph -->
-          <Paint Format="3"><!-- PaintLinearGradient -->
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="4"><!-- PaintLinearGradient -->
             <ColorLine>
               <Extend value="pad"/>
               <!-- StopCount=2 -->

--- a/tests/linear_gradient_rect_colr_1.ttx
+++ b/tests/linear_gradient_rect_colr_1.ttx
@@ -69,7 +69,7 @@
       <!-- BaseGlyphCount=1 -->
       <BaseGlyphV1Record index="0">
         <BaseGlyph value="e000"/>
-        <Paint Format="5"><!-- PaintGlyph -->
+        <Paint Format="6"><!-- PaintGlyph -->
           <Paint Format="3"><!-- PaintLinearGradient -->
             <ColorLine>
               <Extend value="pad"/>

--- a/tests/outside_viewbox_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_clipped_colr_1.ttx
@@ -98,7 +98,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=2 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -107,7 +107,7 @@
         </Paint>
         <Glyph value="g_25fd.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>

--- a/tests/outside_viewbox_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_clipped_colr_1.ttx
@@ -98,7 +98,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=2 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -107,7 +107,7 @@
         </Paint>
         <Glyph value="g_25fd.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>

--- a/tests/outside_viewbox_not_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_not_clipped_colr_1.ttx
@@ -129,7 +129,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=3 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -138,7 +138,7 @@
         </Paint>
         <Glyph value="g_25fd.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -147,7 +147,7 @@
         </Paint>
         <Glyph value="g_25fd.1"/>
       </Paint>
-      <Paint index="2" Format="6"><!-- PaintGlyph -->
+      <Paint index="2" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>

--- a/tests/outside_viewbox_not_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_not_clipped_colr_1.ttx
@@ -129,7 +129,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=3 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -138,7 +138,7 @@
         </Paint>
         <Glyph value="g_25fd.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>
@@ -147,7 +147,7 @@
         </Paint>
         <Glyph value="g_25fd.1"/>
       </Paint>
-      <Paint index="2" Format="5"><!-- PaintGlyph -->
+      <Paint index="2" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -69,8 +69,8 @@
       <!-- BaseGlyphCount=1 -->
       <BaseGlyphV1Record index="0">
         <BaseGlyph value="e000"/>
-        <Paint Format="5"><!-- PaintGlyph -->
-          <Paint Format="7"><!-- PaintTransform -->
+        <Paint Format="6"><!-- PaintGlyph -->
+          <Paint Format="8"><!-- PaintTransform -->
             <Paint Format="4"><!-- PaintRadialGradient -->
               <ColorLine>
                 <Extend value="repeat"/>

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -69,9 +69,9 @@
       <!-- BaseGlyphCount=1 -->
       <BaseGlyphV1Record index="0">
         <BaseGlyph value="e000"/>
-        <Paint Format="6"><!-- PaintGlyph -->
-          <Paint Format="8"><!-- PaintTransform -->
-            <Paint Format="4"><!-- PaintRadialGradient -->
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="12"><!-- PaintTransform -->
+            <Paint Format="6"><!-- PaintRadialGradient -->
               <ColorLine>
                 <Extend value="repeat"/>
                 <!-- StopCount=2 -->

--- a/tests/rect_colr_1.ttx
+++ b/tests/rect_colr_1.ttx
@@ -89,7 +89,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=2 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -98,7 +98,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>

--- a/tests/rect_colr_1.ttx
+++ b/tests/rect_colr_1.ttx
@@ -89,7 +89,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=2 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -98,7 +98,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>

--- a/tests/rects_colr_1.ttx
+++ b/tests/rects_colr_1.ttx
@@ -108,7 +108,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=4 -->
-      <Paint index="0" Format="5"><!-- PaintGlyph -->
+      <Paint index="0" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -117,7 +117,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="5"><!-- PaintGlyph -->
+      <Paint index="1" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -126,7 +126,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="5"><!-- PaintGlyph -->
+      <Paint index="2" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -135,7 +135,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="3" Format="5"><!-- PaintGlyph -->
+      <Paint index="3" Format="6"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>

--- a/tests/rects_colr_1.ttx
+++ b/tests/rects_colr_1.ttx
@@ -108,7 +108,7 @@
     </BaseGlyphV1List>
     <LayerV1List>
       <!-- LayerCount=4 -->
-      <Paint index="0" Format="6"><!-- PaintGlyph -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -117,7 +117,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="6"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="0"/>
@@ -126,7 +126,7 @@
         </Paint>
         <Glyph value="e000.1"/>
       </Paint>
-      <Paint index="2" Format="6"><!-- PaintGlyph -->
+      <Paint index="2" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="2"/>
@@ -135,7 +135,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="3" Format="6"><!-- PaintGlyph -->
+      <Paint index="3" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <Color>
             <PaletteIndex value="1"/>


### PR DESCRIPTION
format numbers changed after the introduction of PaintSweepGradient, and the non-variable Paint formats.
Tests need updating.

This PR depends on fonttools >= 4.20.0