### PR TITLE
Add user configured ascent, descent, transform

### DIFF
--- a/tests/colr_to_svg.py
+++ b/tests/colr_to_svg.py
@@ -49,8 +49,12 @@ from fontTools.ttLib.tables import otTables
 _GRADIENT_PAINT_FORMATS = (PaintLinearGradient.format, PaintRadialGradient.format)
 
 
-def _map_font_emsquare_to_viewbox(upem: int, view_box: Rect) -> Affine2D:
-    return color_glyph.map_viewbox_to_font_emsquare(view_box, upem).inverse()
+def _map_font_emsquare_to_viewbox(
+    view_box: Rect, upem: int, user_transform: Affine2D
+) -> Affine2D:
+    return color_glyph.map_viewbox_to_font_emsquare(
+        view_box, upem, user_transform
+    ).inverse()
 
 
 def _svg_root(view_box: Rect) -> etree.Element:
@@ -158,7 +162,9 @@ def _colr_v0_glyph_to_svg(
     glyph_name: str,
 ) -> etree.Element:
     svg_root = _svg_root(view_box)
-    upem_to_vbox = _map_font_emsquare_to_viewbox(ttfont["head"].unitsPerEm, view_box)
+    upem_to_vbox = _map_font_emsquare_to_viewbox(
+        view_box, ttfont["head"].unitsPerEm, Affine2D.identity()
+    )
 
     for glyph_layer in ttfont["COLR"].ColorLayers[glyph_name]:
         svg_path = etree.SubElement(svg_root, "path")
@@ -256,7 +262,9 @@ def _colr_v1_glyph_to_svg(
 ) -> etree.Element:
     glyph_set = ttfont.getGlyphSet()
     svg_root = _svg_root(view_box)
-    upem_to_vbox = _map_font_emsquare_to_viewbox(ttfont["head"].unitsPerEm, view_box)
+    upem_to_vbox = _map_font_emsquare_to_viewbox(
+        view_box, ttfont["head"].unitsPerEm, Affine2D.identity()
+    )
     _colr_v1_paint_to_svg(ttfont, glyph_set, svg_root, upem_to_vbox, glyph.Paint)
     return svg_root
 

--- a/tests/one_rect_transformed.ttx
+++ b/tests/one_rect_transformed.ttx
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".space"/>
+    <GlyphID id="2" name="e000"/>
+    <GlyphID id="3" name="e000.0"/>
+  </GlyphOrder>
+
+  <hmtx>
+    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".space" width="120" lsb="0"/>
+    <mtx name="e000" width="120" lsb="0"/>
+    <mtx name="e000.0" width="120" lsb="4"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name=".space"/><!-- contains no outline data -->
+
+    <TTGlyph name="e000" xMin="0" yMin="0" xMax="100" yMax="100">
+      <contour>
+        <pt x="100" y="100" on="1"/>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="e000.0" xMin="4" yMin="42" xMax="32" yMax="85">
+      <contour>
+        <pt x="4" y="53" on="1"/>
+        <pt x="11" y="42" on="1"/>
+        <pt x="32" y="74" on="1"/>
+        <pt x="25" y="85" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphV1List>
+      <!-- BaseGlyphCount=1 -->
+      <BaseGlyphV1Record index="0">
+        <BaseGlyph value="e000"/>
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="2"><!-- PaintSolid -->
+            <Color>
+              <PaletteIndex value="0"/>
+              <Alpha value="1.0"/>
+            </Color>
+          </Paint>
+          <Glyph value="e000.0"/>
+        </Paint>
+      </BaseGlyphV1Record>
+    </BaseGlyphV1List>
+    <LayerV1List>
+      <!-- LayerCount=0 -->
+    </LayerV1List>
+  </COLR>
+
+  <CPAL>
+    <version value="0"/>
+    <numPaletteEntries value="1"/>
+    <palette index="0">
+      <color index="0" value="#0000FFFF"/>
+    </palette>
+  </CPAL>
+
+</ttFont>

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -57,6 +57,7 @@ def color_font_config(config_overrides, svgs, tmp_dir=None):
         ._replace(
             family="UnitTest",
             upem=100,
+            width=100,
             keep_glyph_names=True,
             fea_file=fea_file,
         )

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -14,6 +14,7 @@
 
 
 from nanoemoji import write_font
+from picosvg.svg_transform import Affine2D
 import pytest
 import test_helper
 
@@ -123,6 +124,18 @@ def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
             ("reused_shape.svg",),
             "reused_shape_glyf.ttx",
             {"color_format": "glyf"},
+        ),
+        # Confirm we can apply a user transform, override some basic metrics
+        (
+            ("one_rect.svg",),
+            "one_rect_transformed.ttx",
+            {
+                "color_format": "glyf_colr_1",
+                "transform": Affine2D.fromstring(
+                    "scale(0.5, 0.75) translate(50) rotate(45)"
+                ),
+                "width": 120,
+            },
         ),
     ],
 )


### PR DESCRIPTION
WIP. Meant to fix #2.

Built on https://github.com/googlefonts/nanoemoji/pull/249.

As we parse svg style transform strings things like `nanoemoji emoji_u2702.svg --transform "translate(-512,-512) scale(1.17) translate(512, 512)"` become possible on CLI or in config file.

For reference, values from a test run of the Noto emoji_builder:

```
Loaded font 'NotoColorEmoji.tmpl.ttf'.
Font metrics: upem=2048 ascent=1900 descent=500.

Looking for images matching 'build/compressed_pngs/emoji_u*.png'.
Found images for 1 characters in 'build/compressed_pngs/emoji_u*.png'.
Embedding images for 1 glyphs for this strike.
Strike ppem set to 109.
width 136
height 128
ascent 1900
descent 500
upem 2048
y_ppem 109
x_bearing 0
line_height 127.734375
line_ascent 101.123046875
y_bearing 101
```

Scaling up can easily put content outside bbox because we don't compute it currently (#238)