### PR TITLE
Add font version_major and version_minor options

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -49,13 +49,14 @@ _COLOR_FORMATS = [
 
 # we use None as a sentinel for flag not set; FontConfig class has the actual defaults.
 # CLI flags override config file (which overrides default FontConfig).
-flags.DEFINE_string("config", None, "Config file")
+flags.DEFINE_string("config", None, "Config file.")
 flags.DEFINE_integer("upem", None, "Units per em.")
 flags.DEFINE_integer("width", None, "Width.")
 flags.DEFINE_integer("ascent", None, "Ascender")
 flags.DEFINE_integer("descent", None, "Descender.")
 flags.DEFINE_string("transform", None, "User transform, in font coordinates.")
-
+flags.DEFINE_integer("version_major", None, "Major version.")
+flags.DEFINE_integer("version_minor", None, "Minor version.")
 flags.DEFINE_string("family", None, "Family name.")
 flags.DEFINE_string("output_file", None, "Output filename.")
 flags.DEFINE_enum(
@@ -65,12 +66,12 @@ flags.DEFINE_enum(
     "Type of font to generate.",
 )
 flags.DEFINE_enum(
-    "output", None, ["ufo", "font"], "Whether to output a font binary or a UFO"
+    "output", None, ["ufo", "font"], "Whether to output a font binary or a UFO."
 )
 flags.DEFINE_bool(
     "keep_glyph_names", None, "Whether or not to store glyph names in the font."
 )
-flags.DEFINE_bool("clip_to_viewbox", None, "Whether to clip content outside viewbox")
+flags.DEFINE_bool("clip_to_viewbox", None, "Whether to clip content outside viewbox.")
 flags.DEFINE_float(
     "reuse_tolerance",
     None,
@@ -115,6 +116,8 @@ class FontConfig(NamedTuple):
     ascent: int = 950  # default based on Noto Emoji
     descent: int = -250  # default based on Noto Emoji
     transform: Affine2D = Affine2D.identity()
+    version_major: int = 1
+    version_minor: int = 0
     reuse_tolerance: float = 0.1
     ignore_reuse_error: bool = True
     keep_glyph_names: bool = False
@@ -145,6 +148,8 @@ def write(dest: Path, config: FontConfig):
         "ascent": config.ascent,
         "descent": config.descent,
         "transform": config.transform.tostring(),
+        "version_major": config.version_major,
+        "version_minor": config.version_minor,
         "reuse_tolerance": config.reuse_tolerance,
         "ignore_reuse_error": config.ignore_reuse_error,
         "keep_glyph_names": config.keep_glyph_names,
@@ -225,6 +230,8 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
     if not isinstance(transform, Affine2D):
         assert isinstance(transform, str)
         transform = Affine2D.fromstring(transform)
+    version_major = int(_pop_flag(config, "version_major"))
+    version_minor = int(_pop_flag(config, "version_minor"))
     reuse_tolerance = float(_pop_flag(config, "reuse_tolerance"))
     ignore_reuse_error = _pop_flag(config, "ignore_reuse_error")
     keep_glyph_names = _pop_flag(config, "keep_glyph_names")
@@ -297,6 +304,8 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         ascent=ascent,
         descent=descent,
         transform=transform,
+        version_major=version_major,
+        version_minor=version_minor,
         reuse_tolerance=reuse_tolerance,
         ignore_reuse_error=ignore_reuse_error,
         keep_glyph_names=keep_glyph_names,

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -146,6 +146,9 @@ def _ufo(config: FontConfig) -> ufoLib2.Font:
     ufo.info.ascender = config.ascent
     ufo.info.descender = config.descent
     ufo.info.unitsPerEm = config.upem
+    # version
+    ufo.info.versionMajor = config.version_major
+    ufo.info.versionMinor = config.version_minor
 
     # Must have .notdef and Win 10 Chrome likes a blank gid1 so make gid1 space
     ufo.newGlyph(".notdef")

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -43,6 +43,62 @@ def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
         assert ufo.glyphOrder != ttfont.getGlyphOrder()
 
 
+@pytest.mark.parametrize("svgs", [("rect.svg", "one-o-clock.svg")])
+@pytest.mark.parametrize(
+    "color_format",
+    [
+        "cff_colr_0",
+        "cff_colr_1",
+        "glyf_colr_0",
+        "glyf_colr_1",
+        "picosvg",
+    ],
+)
+# Default version is 1.000
+def test_default_version(svgs, color_format):
+    config, glyph_inputs = test_helper.color_font_config(
+        {
+            "color_format": color_format,
+        },
+        svgs,
+    )
+    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ttfont = test_helper.reload_font(ttfont)
+
+    assert ufo.info.versionMajor == 1
+    assert ufo.info.versionMinor == 0
+
+
+@pytest.mark.parametrize("svgs", [("rect.svg", "one-o-clock.svg")])
+@pytest.mark.parametrize(
+    "color_format",
+    [
+        "cff_colr_0",
+        "cff_colr_1",
+        "glyf_colr_0",
+        "glyf_colr_1",
+        "picosvg",
+    ],
+)
+@pytest.mark.parametrize("version_major", [16])
+@pytest.mark.parametrize("version_minor", [28])
+# Test version 16.28
+def test_version(svgs, color_format, version_major, version_minor):
+    config, glyph_inputs = test_helper.color_font_config(
+        {
+            "color_format": color_format,
+            "version_major": version_major,
+            "version_minor": version_minor,
+        },
+        svgs,
+    )
+    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ttfont = test_helper.reload_font(ttfont)
+
+    assert ufo.info.versionMajor == 16
+    assert ufo.info.versionMinor == 28
+
+
 # TODO test that width, height are removed from svg
 # TODO test that enable-background is removed from svg
 # TODO test that id=glyph# is added to svg


### PR DESCRIPTION
https://docs.microsoft.com/en-us/typography/opentype/otspec181/name#name-ids:~:text=Version%20string

> Version string. Should begin with the syntax ‘Version <number>.<number>’ (upper case, lower case, or mixed, with a space between “Version” and the number).
>
>The string must contain a version number of the following form: one or more digits (0-9) of value less than 65,535, followed by a period, followed by one or more digits of value less than 65,535. Any character other than a digit will terminate the minor number. A character such as “;” is helpful to separate different pieces of version information.
>
>The first such match in the string can be used by installation software to compare font versions. Note that some installers may require the string to start with “Version ”, followed by a version number as above.