### PR TITLE
scale height to (ascender-descender), preserve aspect, center width

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -329,6 +329,13 @@ def _painted_layers(
                 yield PaintedLayer(paint, path.d)
 
 
+def _color_glyph_advance_width(view_box: Rect, config: FontConfig) -> int:
+    # Scale advance width proportionally to viewbox aspect ratio.
+    # Use the default advance width if it's larger than the proportional one.
+    font_height = config.ascent - config.descent  # descent <= 0
+    return max(config.width, round(font_height * view_box.w / view_box.h))
+
+
 class ColorGlyph(NamedTuple):
     ufo: ufoLib2.Font
     filename: str
@@ -355,7 +362,7 @@ class ColorGlyph(NamedTuple):
         # non-square aspect ratio == proportional width; square == monospace
         view_box = svg.view_box()
         if view_box is not None:
-            base_glyph.width = round(font_config.width * view_box.w / view_box.h)
+            base_glyph.width = _color_glyph_advance_width(view_box, font_config)
         else:
             base_glyph.width = font_config.width
 

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -89,7 +89,7 @@ def _get_gradient_transform(
     glyph_width: int,
 ) -> Affine2D:
     transform = map_viewbox_to_font_space(
-        view_box, config.ascent, config.descent, glyph_width, config.transform
+        view_box, config.ascender, config.descender, glyph_width, config.transform
     )
 
     gradient_units = grad_el.attrib.get("gradientUnits", "objectBoundingBox")
@@ -151,7 +151,7 @@ def _parse_radial_gradient(
     r1 = gradient.r
 
     transform = map_viewbox_to_font_space(
-        view_box, config.ascent, config.descent, glyph_width, config.transform
+        view_box, config.ascender, config.descender, glyph_width, config.transform
     )
 
     gradient_units = grad_el.attrib.get("gradientUnits", "objectBoundingBox")
@@ -332,7 +332,7 @@ def _painted_layers(
 def _color_glyph_advance_width(view_box: Rect, config: FontConfig) -> int:
     # Scale advance width proportionally to viewbox aspect ratio.
     # Use the default advance width if it's larger than the proportional one.
-    font_height = config.ascent - config.descent  # descent <= 0
+    font_height = config.ascender - config.descender  # descender <= 0
     return max(config.width, round(font_height * view_box.w / view_box.h))
 
 

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -339,7 +339,13 @@ class ColorGlyph(NamedTuple):
         logging.debug(" ColorGlyph for %s (%s)", filename, codepoints)
         glyph_name = glyph.glyph_name(codepoints)
         base_glyph = ufo.newGlyph(glyph_name)
-        base_glyph.width = font_config.width
+
+        # non-square aspect ratio == proportional width; square == monospace
+        view_box = svg.view_box()
+        if view_box is not None:
+            base_glyph.width = round(font_config.width * view_box.w / view_box.h)
+        else:
+            base_glyph.width = font_config.width
 
         # Setup direct access to the glyph if possible
         if len(codepoints) == 1:

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -40,6 +40,7 @@ import ufoLib2
 def _scale_viewbox_to_font_metrics(
     view_box: Rect, ascender: int, descender: int, width: int
 ):
+    assert descender <= 0
     # scale height to (ascender - descender)
     scale = (ascender - descender) / view_box.h
     # shift so width is centered
@@ -381,11 +382,10 @@ class ColorGlyph(NamedTuple):
             )
         return view_box is not None
 
-    def transform_for_font_space(self):
-        """Creates a Transform to map SVG coords to font coords"""
+    def _transform(self, map_fn):
         if not self._has_viewbox_for_transform():
             return Affine2D.identity()
-        return map_viewbox_to_font_space(
+        return map_fn(
             self.svg.view_box(),
             self.ufo.info.ascender,
             self.ufo.info.descender,
@@ -394,16 +394,10 @@ class ColorGlyph(NamedTuple):
         )
 
     def transform_for_otsvg_space(self):
-        """Creates a Transform to map SVG coords OT-SVG coords"""
-        if not self._has_viewbox_for_transform():
-            return Affine2D.identity()
-        return map_viewbox_to_otsvg_space(
-            self.svg.view_box(),
-            self.ufo.info.ascender,
-            self.ufo.info.descender,
-            self.ufo[self.glyph_name].width,
-            self.user_transform,
-        )
+        return self._transform(map_viewbox_to_otsvg_space)
+
+    def transform_for_font_space(self):
+        return self._transform(map_viewbox_to_font_space)
 
     def paints(self):
         """Set of Paint used by this glyph."""

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -137,6 +137,17 @@ class FontConfig(NamedTuple):
     def has_picosvgs(self):
         return not self.color_format.startswith("untouchedsvg")
 
+    def validate(self):
+        for attr_name in ("upem", "width", "ascent", "version_major", "version_minor"):
+            value = getattr(self, attr_name)
+            if value < 0:
+                raise ValueError(f"'{attr_name}' must be zero or positive")
+
+        if self.descent > 0:
+            raise ValueError("'descent' must be zero or negative")
+
+        return self
+
 
 def write(dest: Path, config: FontConfig):
     toml_cfg = {
@@ -316,4 +327,4 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         axes=tuple(axes),
         masters=tuple(masters),
         source_names=tuple(sorted(source_names)),
-    )
+    ).validate()

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -112,7 +112,7 @@ class FontConfig(NamedTuple):
     output_file: str = "AnEmojiFamily.ttf"
     color_format: str = "glyf_colr_1"
     upem: int = 1024
-    width: int = 1024
+    width: int = 1275  # default based on Noto Emoji
     ascent: int = 950  # default based on Noto Emoji
     descent: int = -250  # default based on Noto Emoji
     transform: Affine2D = Affine2D.identity()

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -52,8 +52,8 @@ _COLOR_FORMATS = [
 flags.DEFINE_string("config", None, "Config file.")
 flags.DEFINE_integer("upem", None, "Units per em.")
 flags.DEFINE_integer("width", None, "Width.")
-flags.DEFINE_integer("ascent", None, "Ascender")
-flags.DEFINE_integer("descent", None, "Descender.")
+flags.DEFINE_integer("ascender", None, "Ascender")
+flags.DEFINE_integer("descender", None, "Descender.")
 flags.DEFINE_string("transform", None, "User transform, in font coordinates.")
 flags.DEFINE_integer("version_major", None, "Major version.")
 flags.DEFINE_integer("version_minor", None, "Minor version.")
@@ -113,8 +113,8 @@ class FontConfig(NamedTuple):
     color_format: str = "glyf_colr_1"
     upem: int = 1024
     width: int = 1275  # default based on Noto Emoji
-    ascent: int = 950  # default based on Noto Emoji
-    descent: int = -250  # default based on Noto Emoji
+    ascender: int = 950  # default based on Noto Emoji
+    descender: int = -250  # default based on Noto Emoji
     transform: Affine2D = Affine2D.identity()
     version_major: int = 1
     version_minor: int = 0
@@ -138,13 +138,19 @@ class FontConfig(NamedTuple):
         return not self.color_format.startswith("untouchedsvg")
 
     def validate(self):
-        for attr_name in ("upem", "width", "ascent", "version_major", "version_minor"):
+        for attr_name in (
+            "upem",
+            "width",
+            "ascender",
+            "version_major",
+            "version_minor",
+        ):
             value = getattr(self, attr_name)
             if value < 0:
                 raise ValueError(f"'{attr_name}' must be zero or positive")
 
-        if self.descent > 0:
-            raise ValueError("'descent' must be zero or negative")
+        if self.descender > 0:
+            raise ValueError("'descender' must be zero or negative")
 
         return self
 
@@ -156,8 +162,8 @@ def write(dest: Path, config: FontConfig):
         "color_format": config.color_format,
         "upem": config.upem,
         "width": config.width,
-        "ascent": config.ascent,
-        "descent": config.descent,
+        "ascender": config.ascender,
+        "descender": config.descender,
         "transform": config.transform.tostring(),
         "version_major": config.version_major,
         "version_minor": config.version_minor,
@@ -235,8 +241,8 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
     color_format = _pop_flag(config, "color_format")
     upem = int(_pop_flag(config, "upem"))
     width = int(_pop_flag(config, "width"))
-    ascent = int(_pop_flag(config, "ascent"))
-    descent = int(_pop_flag(config, "descent"))
+    ascender = int(_pop_flag(config, "ascender"))
+    descender = int(_pop_flag(config, "descender"))
     transform = _pop_flag(config, "transform")
     if not isinstance(transform, Affine2D):
         assert isinstance(transform, str)
@@ -312,8 +318,8 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         color_format=color_format,
         upem=upem,
         width=width,
-        ascent=ascent,
-        descent=descent,
+        ascender=ascender,
+        descender=descender,
         transform=transform,
         version_major=version_major,
         version_minor=version_minor,

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -145,8 +145,8 @@ def _ufo(config: FontConfig) -> ufoLib2.Font:
     ufo.info.familyName = config.family
     # set various font metadata; see the full list of fontinfo attributes at
     # https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#generic-dimension-information
-    ufo.info.ascender = config.ascent
-    ufo.info.descender = config.descent
+    ufo.info.ascender = config.ascender
+    ufo.info.descender = config.descender
     ufo.info.unitsPerEm = config.upem
     # version
     ufo.info.versionMajor = config.version_major

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -325,6 +325,24 @@ def _round_gradient_coordinates(paint, prec=6):
                 ),
             },
         ),
+        (
+            # viewBox="0 0 10 8" (w > h), with a linearGradient from (1, 1) to (9, 1).
+            # The default advance width gets scaled by aspect ratio 1000 * 10/8 == 1250.
+            # Test that linearGradient p0 and p1 are centered horizontally relative to
+            # the scaled advance width (and not relative to the default advance width).
+            "gradient_non_square_viewbox.svg",
+            {
+                PaintLinearGradient(
+                    stops=(
+                        ColorStop(stopOffset=0.1, color=Color.fromstring("blue")),
+                        ColorStop(stopOffset=0.9, color=Color.fromstring("cyan")),
+                    ),
+                    p0=Point(125.0, 875.0),
+                    p1=Point(1125.0, 875.0),
+                    p2=Point(125.0, 125.0),
+                ),
+            },
+        ),
     ],
 )
 def test_paint_from_shape(svg_in, expected_paints):

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -79,7 +79,7 @@ def _nsvg(filename):
             Affine2D(1.171875, 0, 0, -1.171875, 37.5, 950),
             1275,
         ),
-        # viewbox wider than tall
+        # wider than tall: uniformly scale by height and stretch advance width to fit
         (
             "0 0 20 10",
             100,
@@ -89,7 +89,7 @@ def _nsvg(filename):
             Affine2D(a=10, b=0, c=0, d=-10, e=0, f=100),
             200,
         ),
-        # viewbox taller than wide
+        # taller than wide: uniformly scale by height and shrink advance width to fit
         (
             "0 0 10 20",
             100,

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -29,8 +29,8 @@ import ufoLib2
 def _ufo(config):
     ufo = ufoLib2.Font()
     ufo.info.unitsPerEm = config.upem
-    ufo.info.ascender = config.ascent
-    ufo.info.descender = config.descent
+    ufo.info.ascender = config.ascender
+    ufo.info.descender = config.descender
     return ufo
 
 
@@ -111,7 +111,7 @@ def test_transform_and_width(
         "/>"
     )
     config = FontConfig(
-        upem=upem, width=width, ascent=ascender, descent=descender
+        upem=upem, width=width, ascender=ascender, descender=descender
     ).validate()
     ufo = _ufo(config)
     color_glyph = ColorGlyph.create(
@@ -348,7 +348,7 @@ def _round_gradient_coordinates(paint, prec=6):
     ],
 )
 def test_paint_from_shape(svg_in, expected_paints):
-    config = FontConfig(upem=1000, ascent=1000, descent=0, width=1000)
+    config = FontConfig(upem=1000, ascender=1000, descender=0, width=1000)
     color_glyph = ColorGlyph.create(
         config, _ufo(config), "duck", 1, [0x0042], _nsvg(svg_in)
     )

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -59,15 +59,15 @@ def _nsvg(filename):
             Affine2D(8, 0, 0, -8, 1208, 3400),
             1024,
         ),
-        # made up example. Scale, translate, flip y
+        # made up example. Scale, translate, flip y, center horizontally
         (
             "10 11 20 21",
             100,
             100,
             100,
             0,
-            Affine2D(a=4.761905, b=0, c=0, d=-4.761905, e=-47.738095, f=152.380952),
-            95,
+            Affine2D(a=4.761905, b=0, c=0, d=-4.761905, e=-45.238095, f=152.380952),
+            100,
         ),
         # noto emoji width, ascender, descender
         (
@@ -89,15 +89,15 @@ def _nsvg(filename):
             Affine2D(a=10, b=0, c=0, d=-10, e=0, f=100),
             200,
         ),
-        # taller than wide: uniformly scale by height and shrink advance width to fit
+        # taller than wide: uniformly scale by height, center within advance width
         (
             "0 0 10 20",
             100,
             100,
             100,
             0,
-            Affine2D(a=5, b=0, c=0, d=-5, e=0, f=100),
-            50,
+            Affine2D(a=5, b=0, c=0, d=-5, e=25, f=100),
+            100,
         ),
     ],
 )

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -110,7 +110,9 @@ def test_transform_and_width(
         f' viewBox="{view_box}"'
         "/>"
     )
-    config = FontConfig(upem=upem, width=width, ascent=ascender, descent=descender)
+    config = FontConfig(
+        upem=upem, width=width, ascent=ascender, descent=descender
+    ).validate()
     ufo = _ufo(config)
     color_glyph = ColorGlyph.create(
         config, ufo, "duck", 1, [0x0042], SVG.fromstring(svg_str)

--- a/tests/gradient_non_square_viewbox.svg
+++ b/tests/gradient_non_square_viewbox.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 10 8" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="grad1">
+      <stop offset="0.1"  stop-color="blue" />
+      <stop offset="0.9" stop-color="cyan" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="8" height="6" fill="url(#grad1)" />
+</svg>

--- a/tests/one_rect_transformed.ttx
+++ b/tests/one_rect_transformed.ttx
@@ -12,8 +12,8 @@
   <hmtx>
     <mtx name=".notdef" width="0" lsb="0"/>
     <mtx name=".space" width="120" lsb="0"/>
-    <mtx name="e000" width="120" lsb="4"/>
-    <mtx name="e000.0" width="120" lsb="4"/>
+    <mtx name="e000" width="120" lsb="7"/>
+    <mtx name="e000.0" width="120" lsb="7"/>
   </hmtx>
 
   <cmap>
@@ -41,20 +41,20 @@
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 
-    <TTGlyph name="e000" xMin="4" yMin="42" xMax="32" yMax="85">
+    <TTGlyph name="e000" xMin="7" yMin="48" xMax="36" yMax="90">
       <contour>
-        <pt x="32" y="85" on="1"/>
-        <pt x="4" y="42" on="1"/>
+        <pt x="36" y="90" on="1"/>
+        <pt x="7" y="48" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="e000.0" xMin="4" yMin="42" xMax="32" yMax="85">
+    <TTGlyph name="e000.0" xMin="7" yMin="48" xMax="36" yMax="90">
       <contour>
-        <pt x="4" y="53" on="1"/>
-        <pt x="11" y="42" on="1"/>
-        <pt x="32" y="74" on="1"/>
-        <pt x="25" y="85" on="1"/>
+        <pt x="7" y="58" on="1"/>
+        <pt x="14" y="48" on="1"/>
+        <pt x="36" y="80" on="1"/>
+        <pt x="29" y="90" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -57,6 +57,8 @@ def color_font_config(config_overrides, svgs, tmp_dir=None):
         ._replace(
             family="UnitTest",
             upem=100,
+            ascent=100,
+            descent=0,
             width=100,
             keep_glyph_names=True,
             fea_file=fea_file,

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -57,8 +57,8 @@ def color_font_config(config_overrides, svgs, tmp_dir=None):
         ._replace(
             family="UnitTest",
             upem=100,
-            ascent=100,
-            descent=0,
+            ascender=100,
+            descender=0,
             width=100,
             keep_glyph_names=True,
             fea_file=fea_file,


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/2#issuecomment-794250786 and https://github.com/googlefonts/nanoemoji/issues/230

Previously we were mapping the SVG viewBox to UPEM square (0, 0, upem, upem), stretching it when the aspect ratio was not square, and setting the advance width to the same monospaced value.

After this PR:

1) the viewbox height is scaled to match the sum of font (ascender - descender), and the width is scaled by the same factor (thus preserving the aspect ratio); the design centered horizontally within the glyph advance width. This is what NotoColorEmoji also does, and it makes the emoji designs look more visually centered when set alongside normal text (#2).
2) changed the default FontConfig.width to the same value of NotoColorEmoji: this is wider than default upem, and a bit wider than the default (ascender - descender). Rationale: if it looks good with noto-emoji, should look good enough for other emoji designs too
3) the advance width is now proportional to the aspect ratio: i.e. if viewbox width == height (square viewbox), then the nominal width doesn't change, and if all input SVGs have square ratio the font will be monospaced (all advance widths == config.width); if a viewbox is non-square (like the example duck in #230), then the advance width is also scaled to fit the scaled viewbox; thus a glyph advance width can be wider or narrower than the nominal width depending on the input SVG aspect ratio.