### PR TITLE
Set openTypeOS2TypoLineGap=0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,9 @@ setup(
         ],
     },
     python_requires=">=3.6",
-
     # this is for type checker to use our inline type hints:
     # https://www.python.org/dev/peps/pep-0561/#id18
     package_data={"picosvg": ["py.typed"]},
-
     # metadata to display on PyPI
     author="Rod S",
     author_email="rsheeter@google.com",

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -152,6 +152,11 @@ def _ufo(config: FontConfig) -> ufoLib2.Font:
     ufo.info.versionMajor = config.version_major
     ufo.info.versionMinor = config.version_minor
 
+    # Set OS/2 sTypoLineGap, make it equal to hhea lineGap
+    # https://docs.microsoft.com/en-us/typography/opentype/spec/os2#stypolinegap
+    # The default line gap is OS/2.sTypoAscender - OS/2.sTypoDescender + OS/2.sTypoLineGap
+    ufo.info.openTypeOS2TypoLineGap = 0
+
     # Must have .notdef and Win 10 Chrome likes a blank gid1 so make gid1 space
     ufo.newGlyph(".notdef")
     space = ufo.newGlyph(".space")

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -84,6 +84,28 @@ def test_version(color_format, version_major, version_minor, expected):
     assert ttfont["name"].getDebugName(nameID=5).startswith(f"Version {expected}")
 
 
+@pytest.mark.parametrize(
+    "color_format",
+    [
+        "glyf",
+        "cff_colr_0",
+        "glyf_colr_1",
+        "picosvg",
+    ],
+)
+def test_default_line_gap(color_format):
+    config_overrides = {"color_format": color_format}
+    config, glyph_inputs = test_helper.color_font_config(
+        config_overrides, ("rect.svg", "one-o-clock.svg")
+    )
+    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ttfont = test_helper.reload_font(ttfont)
+
+    assert ufo.info.openTypeOS2TypoLineGap == 0
+    assert ttfont["OS/2"].sTypoLineGap == 0
+    assert ttfont["hhea"].lineGap == 0
+
+
 # TODO test that width, height are removed from svg
 # TODO test that enable-background is removed from svg
 # TODO test that id=glyph# is added to svg


### PR DESCRIPTION
[ufo2ft](https://github.com/googlefonts/ufo2ft/blob/97eb6734397dcb2bc395775c4e342d74cd6474a3/Lib/ufo2ft/fontInfoData.py#L229-L238) currently calculated value is not equal to 0

Mainly refer to the conclusion of this article:
https://simoncozens.github.io/fonts-and-layout/opentype.html#vertical-metrics-hhea-and-os2:~:text=recommended%20method

> To get you started, here is our recommended method (distilled from a [discussion on Typedrawers](http://typedrawers.com/discussion/1705)):
> 
> - The sTypoAscender minus the sTypoDescender should equal the unit square. (Usually 1000 units.)
> 
> - sTypoLinegap should be the default linespacing distance for your intended language environment.
> 
> - lineGap should be zero.
> 
> - usWinAscent and usWinDescent should be set so that no clipping occurs. If your font contains glyphs with tall, stacked accents - for instance, the Vietnamese letter LATIN CAPITAL LETTER A WITH BREVE AND HOOK ABOVE (Ẳ) - you will need to ensure that these values can accommodate the highest (and lowest) possible values of your shaped text. They should also be set so that they sum to at least the value of sTypoAscender - sTypoDescender + sTypoLinegap.
> 
> - ascent and descent should be set to the same values as usWinAscent and usWinDescent, remembering that usWinDescent is positive and descent is negative.
> 
> - Bit 7 of fsSelection should be turned on.