### PR TITLE
set default linegap to 0, allow to customise via --linegap option

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -54,6 +54,7 @@ flags.DEFINE_integer("upem", None, "Units per em.")
 flags.DEFINE_integer("width", None, "Width.")
 flags.DEFINE_integer("ascender", None, "Ascender")
 flags.DEFINE_integer("descender", None, "Descender.")
+flags.DEFINE_integer("linegap", None, "Line gap.")
 flags.DEFINE_string("transform", None, "User transform, in font coordinates.")
 flags.DEFINE_integer("version_major", None, "Major version.")
 flags.DEFINE_integer("version_minor", None, "Minor version.")
@@ -111,10 +112,12 @@ class FontConfig(NamedTuple):
     family: str = "An Emoji Family"
     output_file: str = "AnEmojiFamily.ttf"
     color_format: str = "glyf_colr_1"
+    # metrics default based on Noto Emoji
     upem: int = 1024
-    width: int = 1275  # default based on Noto Emoji
-    ascender: int = 950  # default based on Noto Emoji
-    descender: int = -250  # default based on Noto Emoji
+    width: int = 1275
+    ascender: int = 950
+    descender: int = -250
+    linegap: int = 0
     transform: Affine2D = Affine2D.identity()
     version_major: int = 1
     version_minor: int = 0
@@ -142,6 +145,7 @@ class FontConfig(NamedTuple):
             "upem",
             "width",
             "ascender",
+            "linegap",
             "version_major",
             "version_minor",
         ):
@@ -164,6 +168,7 @@ def write(dest: Path, config: FontConfig):
         "width": config.width,
         "ascender": config.ascender,
         "descender": config.descender,
+        "linegap": config.linegap,
         "transform": config.transform.tostring(),
         "version_major": config.version_major,
         "version_minor": config.version_minor,
@@ -243,6 +248,7 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
     width = int(_pop_flag(config, "width"))
     ascender = int(_pop_flag(config, "ascender"))
     descender = int(_pop_flag(config, "descender"))
+    linegap = int(_pop_flag(config, "linegap"))
     transform = _pop_flag(config, "transform")
     if not isinstance(transform, Affine2D):
         assert isinstance(transform, str)
@@ -320,6 +326,7 @@ def load(config_file: Path = None, additional_srcs: Tuple[Path] = None) -> FontC
         width=width,
         ascender=ascender,
         descender=descender,
+        linegap=linegap,
         transform=transform,
         version_major=version_major,
         version_minor=version_minor,

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -145,9 +145,21 @@ def _ufo(config: FontConfig) -> ufoLib2.Font:
     ufo.info.familyName = config.family
     # set various font metadata; see the full list of fontinfo attributes at
     # https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#generic-dimension-information
-    ufo.info.ascender = config.ascender
-    ufo.info.descender = config.descender
     ufo.info.unitsPerEm = config.upem
+    # we just use a simple scheme that makes all sets of vertical metrics the same;
+    # if one needs more fine-grained control they can fix up post build
+    ufo.info.ascender = (
+        ufo.info.openTypeHheaAscender
+    ) = ufo.info.openTypeOS2TypoAscender = config.ascender
+    ufo.info.descender = (
+        ufo.info.openTypeHheaDescender
+    ) = ufo.info.openTypeOS2TypoDescender = config.descender
+    ufo.info.openTypeHheaLineGap = ufo.info.openTypeOS2TypoLineGap = config.linegap
+    # set USE_TYPO_METRICS flag (OS/2.fsSelection bit 7) to make sure OS/2 Typo* metrics
+    # are preferred to define Windows line spacing over legacy WinAscent/WinDescent:
+    # https://docs.microsoft.com/en-us/typography/opentype/spec/os2#fsselection
+    ufo.info.openTypeOS2Selection = [7]
+
     # version
     ufo.info.versionMajor = config.version_major
     ufo.info.versionMinor = config.version_minor


### PR DESCRIPTION
font vertical metrics is a contentious topic, here I want to keep things simple without opening the can of worms.

With this PR, we set the same default linegap that NotoColorEmoji.ttf uses, ie. 0 (which maximises compatibility across environments).
We set all ascenders/descenders to the same nominal values provided by the user config/CLI flags.
We set fsSelection bit 7 to force the use of typo-metrics for line spacing over the legacy OS/2 winAscent/winDescent.

Note that the winAscent/winDescent may still be relevant for defining clipping zones. However at this time, we don't set them explicitly to the actual font's yMin/yMax but use ufo2ft's fallback values (winAscent == ascender + linegap, winDescent == abs(descender)).
The assumption being emojis are usually contained well within the viewbox. We can revise that later if need be (or potentially fix that in ufo2ft itself).