### PR TITLE
use explicit --output_file instead of bash '>' redirection op

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
-        "picosvg>=0.12.0",
+        "picosvg>=0.12.1",
         "pillow>=7.2.0",
         "regex>=2020.4.4",
         "toml>=0.10.1",

--- a/src/nanoemoji/features.py
+++ b/src/nanoemoji/features.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helps deal with emoji OpenType Layout features."""
+
+# TODO if this is a qualified sequence create the unqualified version and vice versa
+
+
+from nanoemoji.glyph import glyph_name
+
+
+def generate_fea(rgi_sequences):
+    # Generate rlig feature with ligature lookup for multi-codepoint RGIs
+    rules = []
+    rules.append("languagesystem DFLT dflt;")
+    rules.append("languagesystem latn dflt;")
+    rules.append("")
+
+    rules.append("feature rlig {")
+    for rgi in sorted(rgi_sequences):
+        if len(rgi) == 1:
+            continue
+        glyphs = [glyph_name(cp) for cp in rgi]
+        target = glyph_name(rgi)
+        rules.append("  sub %s by %s;" % (" ".join(glyphs), target))
+
+    rules.append("} rlig;")
+    rules.append("")
+    return "\n".join(rules)

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -121,19 +121,20 @@ def write_preamble(nw, font_config: FontConfig):
         f"picosvg",
         f"picosvg "
         + _bool_flag("clip_to_viewbox", font_config.clip_to_viewbox)
-        + " $in > $out",
+        + " --output_file $out"
+        + " $in",
     )
     nw.newline()
 
     module_rule(
         "write_codepoints",
-        "@$out.rsp > $out",
+        "--output_file $out @$out.rsp",
         rspfile="$out.rsp",
         rspfile_content="$in",
     )
     nw.newline()
 
-    module_rule("write_fea", "$in > $out")
+    module_rule("write_fea", "--output_file $out $in")
     nw.newline()
 
     if len(font_config.masters) == 1:

--- a/src/nanoemoji/util.py
+++ b/src/nanoemoji/util.py
@@ -15,6 +15,8 @@
 """Small helper functions."""
 
 import os
+import contextlib
+from functools import partial
 from pathlib import Path
 import shlex
 from typing import List
@@ -56,3 +58,12 @@ def fs_root() -> Path:
 def rel(from_path: Path, to_path: Path) -> Path:
     # relative_to(A,B) doesn't like it if B doesn't start with A
     return Path(os.path.relpath(str(to_path.resolve()), str(from_path.resolve())))
+
+
+@contextlib.contextmanager
+def file_printer(filename):
+    if filename == "-":  # conventionally means print to stdout
+        yield print
+    else:
+        with open(filename, "w") as f:
+            yield partial(print, file=f)

--- a/src/nanoemoji/write_codepoints.py
+++ b/src/nanoemoji/write_codepoints.py
@@ -15,11 +15,23 @@
 """Prints a csv of filename,codepoint sequence"""
 
 from absl import app
+from absl import flags
 from nanoemoji import codepoints
 from nanoemoji import util
 
 
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
+
+
 def main(argv):
+    if FLAGS.output_file != "-":
+        outfile = open(FLAGS.output_file, "w")
+
+        def print(s):
+            outfile.write(s + "\n")
+
     for filename in util.expand_ninja_response_files(argv[1:]):
         if filename.endswith(".txt"):
             with open(filename) as f:

--- a/src/nanoemoji/write_codepoints.py
+++ b/src/nanoemoji/write_codepoints.py
@@ -26,19 +26,14 @@ flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
 def main(argv):
-    if FLAGS.output_file != "-":
-        outfile = open(FLAGS.output_file, "w")
-
-        def print(s):
-            outfile.write(s + "\n")
-
-    for filename in util.expand_ninja_response_files(argv[1:]):
-        if filename.endswith(".txt"):
-            with open(filename) as f:
-                for l in f:
-                    print(codepoints.csv_line(l.strip()))
-        else:
-            print(codepoints.csv_line(filename))
+    with util.file_printer(FLAGS.output_file) as print:
+        for filename in util.expand_ninja_response_files(argv[1:]):
+            if filename.endswith(".txt"):
+                with open(filename) as f:
+                    for l in f:
+                        print(codepoints.csv_line(l.strip()))
+            else:
+                print(codepoints.csv_line(filename))
 
 
 if __name__ == "__main__":

--- a/src/nanoemoji/write_fea.py
+++ b/src/nanoemoji/write_fea.py
@@ -21,6 +21,7 @@ from absl import app
 from absl import flags
 from nanoemoji import codepoints
 from nanoemoji import features
+from nanoemoji import util
 
 
 FLAGS = flags.FLAGS
@@ -29,14 +30,10 @@ flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
 def main(argv):
-    with open(argv[1]) as f:
-        rgi_sequences = sorted(codepoints.parse_csv_line(l)[1] for l in f)
-    output = features.generate_fea(rgi_sequences)
-    if FLAGS.output_file == "-":
-        print(output)
-    else:
-        with open(FLAGS.output_file, "w") as f:
-            f.write(output)
+    with util.file_printer(FLAGS.output_file) as print:
+        with open(argv[1]) as f:
+            rgi_sequences = sorted(codepoints.parse_csv_line(l)[1] for l in f)
+        print(features.generate_fea(rgi_sequences))
 
 
 if __name__ == "__main__":

--- a/src/nanoemoji/write_fea.py
+++ b/src/nanoemoji/write_fea.py
@@ -18,33 +18,25 @@
 
 
 from absl import app
+from absl import flags
 from nanoemoji import codepoints
-from nanoemoji.glyph import glyph_name
+from nanoemoji import features
 
 
-def _generate_fea(rgi_sequences):
-    rules = []
-    rules.append("languagesystem DFLT dflt;")
-    rules.append("languagesystem latn dflt;")
-    rules.append("")
+FLAGS = flags.FLAGS
 
-    rules.append("feature rlig {")
-    for rgi in sorted(rgi_sequences):
-        if len(rgi) == 1:
-            continue
-        glyphs = [glyph_name(cp) for cp in rgi]
-        target = glyph_name(rgi)
-        rules.append("  sub %s by %s;" % (" ".join(glyphs), target))
-
-    rules.append("} rlig;")
-    rules.append("")
-    return "\n".join(rules)
+flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
 def main(argv):
     with open(argv[1]) as f:
         rgi_sequences = sorted(codepoints.parse_csv_line(l)[1] for l in f)
-    print(_generate_fea(rgi_sequences))
+    output = features.generate_fea(rgi_sequences)
+    if FLAGS.output_file == "-":
+        print(output)
+    else:
+        with open(FLAGS.output_file, "w") as f:
+            f.write(output)
 
 
 if __name__ == "__main__":

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -21,7 +21,7 @@ from lxml import etree
 from fontTools import ttLib
 from nanoemoji import codepoints
 from nanoemoji import config
-from nanoemoji import write_fea
+from nanoemoji import features
 from nanoemoji import write_font
 from pathlib import Path
 from picosvg.svg import SVG
@@ -50,7 +50,7 @@ def color_font_config(config_overrides, svgs, tmp_dir=None):
     fea_file = os.path.join(tmp_dir, "test.fea")
     rgi_seqs = tuple(codepoints.from_filename(str(f)) for f in svgs)
     with open(fea_file, "w") as f:
-        f.write(write_fea._generate_fea(rgi_seqs))
+        f.write(features.generate_fea(rgi_seqs))
 
     return (
         config.load(config_file=None, additional_srcs=svgs)


### PR DESCRIPTION
On Windows, ninja uses the system API to create subprocesses that does not support the Bash `>` redirection operator so we must use an explicit `--output_file` command-line option for `nanoemoji.write_fea` and `nanoemoji.write_codepoints` sub-commands.

See https://github.com/googlefonts/nanoemoji/pull/240

NOTE: tests will fail, until similar picosvg PR is merged and released (and picosvg dependency bumped in nanoemoji): https://github.com/googlefonts/picosvg/pull/194