### PR TITLE
pre-apply translation when mapping to/from SVG/font space

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
-        "picosvg>=0.12.1",
+        "picosvg>=0.13.0",
         "pillow>=7.2.0",
         "regex>=2020.4.4",
         "toml>=0.10.1",

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from nanoemoji.colors import Color
-from nanoemoji.color_glyph import ColorGlyph
+from nanoemoji.color_glyph import ColorGlyph, _decompose_uniform_transform
 from nanoemoji.config import FontConfig
 from nanoemoji.paint import *
 from picosvg.svg import SVG
@@ -120,6 +120,35 @@ def test_transform_and_width(
 
     assert color_glyph.transform_for_font_space() == pytest.approx(expected_transform)
     assert ufo[color_glyph.glyph_name].width == expected_width
+
+
+@pytest.mark.parametrize(
+    "transform, expected",
+    [
+        (
+            Affine2D(2, 0, 0, 1, 0, 0),
+            (Affine2D(2, 0, 0, 2, 0, 0), Affine2D(1, 0, 0, 0.5, 0, 0)),
+        ),
+        (
+            Affine2D(8, 0, 0, -8, 0, 1024),
+            (Affine2D(8, 0, 0, -8, 0, 1024), Affine2D(1, 0, 0, 1, 0, 0)),
+        ),
+        (
+            Affine2D.fromstring("rotate(-90) translate(50, -100)"),
+            (Affine2D(1, 0, 0, 1, 50, -100), Affine2D(0, -1.0, 1.0, 0, 0, 0)),
+        ),
+        (
+            Affine2D.fromstring("rotate(90) scale(2)"),
+            (Affine2D(2, 0, 0, 2, 0, 0), Affine2D(0, 1.0, -1.0, 0, 0, 0)),
+        ),
+        (
+            Affine2D.fromstring("translate(50, -100) scale(2) rotate(90)"),
+            (Affine2D(2, 0, 0, 2, -100, -50), Affine2D(0, 1.0, -1.0, 0, 0, 0)),
+        ),
+    ],
+)
+def test_decompose_uniform_transform(transform, expected):
+    assert _decompose_uniform_transform(transform) == expected
 
 
 def _round_gradient_coordinates(paint, prec=6):

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -178,12 +178,29 @@ def _round_gradient_coordinates(paint, prec=6):
                 )
             },
         ),
-        # radial
+        # radial on square using objectBoundingBox (no wrapping PaintTransform needed)
+        (
+            "radial_gradient_square.svg",
+            {
+                PaintRadialGradient(
+                    extend=Extend.REPEAT,
+                    stops=(
+                        ColorStop(stopOffset=0.05, color=Color.fromstring("fuchsia")),
+                        ColorStop(stopOffset=0.75, color=Color.fromstring("orange")),
+                    ),
+                    c0=Point(500, 500),
+                    c1=Point(500, 500),
+                    r0=0,
+                    r1=500,
+                ),
+            },
+        ),
+        # radial on non-square rect using objectBoundingBox
         (
             "radial_gradient_rect.svg",
             {
                 PaintTransform(
-                    transform=(1.0, 0.0, 0.0, 0.333333, 0.0, 533.333333),
+                    transform=(1.0, 0.0, 0.0, 0.333333, 0.0, 0.0),
                     paint=PaintRadialGradient(
                         extend=Extend.REPEAT,
                         stops=(
@@ -194,8 +211,8 @@ def _round_gradient_coordinates(paint, prec=6):
                                 stopOffset=0.75, color=Color.fromstring("orange")
                             ),
                         ),
-                        c0=Point(500, 500),
-                        c1=Point(500, 500),
+                        c0=Point(500, 2100),
+                        c1=Point(500, 2100),
                         r0=0,
                         r1=300,
                     ),
@@ -207,7 +224,7 @@ def _round_gradient_coordinates(paint, prec=6):
             "radial_gradient_transform.svg",
             {
                 PaintTransform(
-                    transform=(1.0, 0.0, -0.36397, 1.0, 363.970234, 0.0),
+                    transform=(0.939693, 0.0, -0.34202, 0.939693, 0.0, 0.0),
                     paint=PaintRadialGradient(
                         stops=(
                             ColorStop(
@@ -220,10 +237,10 @@ def _round_gradient_coordinates(paint, prec=6):
                                 stopOffset=1.0, color=Color.fromstring("darkblue")
                             ),
                         ),
-                        c0=Point(x=325, y=500),
-                        c1=Point(x=325, y=500),
+                        c0=Point(x=733.186809, y=532.088886),
+                        c1=Point(x=733.186809, y=532.088886),
                         r0=0,
-                        r1=500,
+                        r1=532.088886,
                     ),
                 ),
             },
@@ -274,14 +291,14 @@ def _round_gradient_coordinates(paint, prec=6):
             "radial_gradient_transform_2.svg",
             {
                 PaintTransform(
-                    transform=(0.0, -1.0, 0.9288, 0.0, -928.8, 1000.0),
+                    transform=(0.0, -1.0, 0.9288, 0.0, 0.0, 0.0),
                     paint=PaintRadialGradient(
                         stops=(
                             ColorStop(stopOffset=0.0, color=Color.fromstring("white")),
                             ColorStop(stopOffset=1.0, color=Color.fromstring("black")),
                         ),
-                        c0=Point(x=26.875, y=1301.77018),
-                        c1=Point(x=26.875, y=1301.77018),
+                        c0=Point(x=-973.125, y=301.77018),
+                        c1=Point(x=-973.125, y=301.77018),
                         r0=0.0,
                         r1=129.015625,
                     ),
@@ -308,7 +325,7 @@ def _round_gradient_coordinates(paint, prec=6):
                     p2=Point(200.0, 600.0),
                 ),
                 PaintTransform(
-                    transform=(1.0, 0.0, 0.0, 0.333333, 0, 333.333333),
+                    transform=(1.0, 0.0, 0.0, 0.333333, 0, 0),
                     paint=PaintRadialGradient(
                         stops=(
                             ColorStop(
@@ -319,8 +336,8 @@ def _round_gradient_coordinates(paint, prec=6):
                                 color=Color.fromstring("yellow", alpha=0.5 * 0.8),
                             ),
                         ),
-                        c0=Point(x=500.0, y=200.0),
-                        c1=Point(x=500.0, y=200.0),
+                        c0=Point(x=500.0, y=1200.0),
+                        c1=Point(x=500.0, y=1200.0),
                         r0=0.0,
                         r1=300.0,
                     ),

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -91,10 +91,10 @@
                 </ColorStop>
               </ColorLine>
               <x0 value="50"/>
-              <y0 value="50"/>
+              <y0 value="210"/>
               <r0 value="0"/>
               <x1 value="50"/>
-              <y1 value="50"/>
+              <y1 value="210"/>
               <r1 value="30"/>
             </Paint>
             <Transform>
@@ -103,7 +103,7 @@
               <xy value="0.0"/>
               <yy value="0.33333"/>
               <dx value="0.0"/>
-              <dy value="53.33333"/>
+              <dy value="0.0"/>
             </Transform>
           </Paint>
           <Glyph value="e000.0"/>

--- a/tests/radial_gradient_rect_from_colr_1.svg
+++ b/tests/radial_gradient_rect_from_colr_1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
   <defs>
-    <radialGradient id="g1" cx="5" cy="5" r="3" gradientUnits="userSpaceOnUse" spreadMethod="repeat" gradientTransform="matrix(1 0 0 0.333 0 1.333)">
+    <radialGradient id="g1" cx="5" cy="9" r="3" gradientUnits="userSpaceOnUse" spreadMethod="repeat" gradientTransform="matrix(1 0 0 0.333 0 0)">
       <stop offset="0.05" stop-color="fuchsia"/>
       <stop offset="0.75" stop-color="orange"/>
     </radialGradient>

--- a/tests/radial_gradient_square.svg
+++ b/tests/radial_gradient_square.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <radialGradient id="grad1"
+                    spreadMethod="repeat" >
+      <stop offset="5%"  stop-color="fuchsia"/>
+      <stop offset="0.75" stop-color="orange"/>
+    </radialGradient>
+  </defs>
+  <rect x="0" y="0" width="10" height="10" fill="url(#grad1)" />
+</svg>


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/243

Depends on https://github.com/googlefonts/picosvg/pull/198

When we map from SVG viewbox space to font EM units, we may incur in situations like https://github.com/googlefonts/nanoemoji/issues/243 when a PaintTransform value overflows fixed limits and gives a struct.error. 
If we pre-apply the translation part of the matrix to the gradient geometry instead of encoding it as part of the wrapping PaintTransform, we fix these.

Test will fail until https://github.com/googlefonts/picosvg/pull/198 gets merged 