### PR TITLE
strip whitespace when parsing Color.fromstring

### DIFF
--- a/src/nanoemoji/colors.py
+++ b/src/nanoemoji/colors.py
@@ -188,6 +188,7 @@ class Color(collections.namedtuple("Color", "red green blue alpha")):
     @classmethod
     def fromstring(cls, s, alpha=1.0):
         # https://www.w3.org/TR/css-color-4/#hex-notation
+        s = s.strip()
         if s.startswith("#"):
             ss = s[1:]
             if len(ss) in (3, 4):

--- a/tests/colors_test.py
+++ b/tests/colors_test.py
@@ -33,6 +33,8 @@ import pytest
         ("rgb(0, 256, -1)", Color(0, 255, 0, 1.0)),
         # rgb(r g b)
         ("rgb(42 101 43)", Color(42, 101, 43, 1.0)),
+        # extra whitespace as found in the noto-emoji Luxembourg flag
+        ("#00A1DE\n", Color(0, 161, 222, 1.0)),
     ],
 )
 def test_color_fromstring(color_string, expected_color):


### PR DESCRIPTION
The Noto Emoji Luxembourg flag LU.svg has a color fill with extra whitespace at the end...

https://github.com/googlefonts/noto-emoji/blob/main/third_party/region-flags/svg/LU.svg