### PR TITLE
work around Safari's bug when gradientTransform contains "involutory" matrix

### DIFF
--- a/tests/involutory_matrix.svg
+++ b/tests/involutory_matrix.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="1000" height="1000">
+  <defs>
+    <!-- testing Safari's quirk when gradientTransform contains a matrix whose inverse == itself
+    https://github.com/googlefonts/nanoemoji/issues/268 -->
+    <radialGradient id="a" gradientTransform="scale(-1 1)" gradientUnits="userSpaceOnUse" cx="-64" cy="64" r="64" fx="-32" fy="32" fr="0">
+      <stop offset="0" stop-color="red"/>
+      <stop offset="1" stop-color="blue"/>
+    </radialGradient>
+  </defs>
+  <rect width="128" height="128" fill="url(#a)"/>
+</svg>

--- a/tests/involutory_matrix_picosvg.ttx
+++ b/tests/involutory_matrix_picosvg.ttx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".space"/>
+    <GlyphID id="2" name="e000"/>
+  </GlyphOrder>
+
+  <hmtx>
+    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".space" width="100" lsb="0"/>
+    <mtx name="e000" width="100" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name=".space"/><!-- contains no outline data -->
+
+    <TTGlyph name="e000"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <SVG>
+
+    <svgDoc endGlyphID="2" startGlyphID="2">
+      <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" version="1.1"><defs><radialGradient id="g1" fx="-32" fy="32" cx="-64" cy="64" r="64" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.99999 0 0 1 0 0)"><stop offset="0" stop-color="red"/><stop offset="1" stop-color="blue"/></radialGradient></defs><g id="glyph2" transform="matrix(0.781 0 0 0.781 0 -100)"><path d="M0,0 H128 V128 H0 V0 Z" fill="url(#g1)"/></g></svg>]]>
+    </svgDoc>
+  </SVG>
+
+</ttFont>

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -224,6 +224,14 @@ def test_vertical_metrics(ascender, descender, linegap):
             "reused_shape_2_picosvg.ttx",
             {"color_format": "picosvg"},
         ),
+        # Safari can't deal with gradientTransform where matrix.inverse() == self,
+        # we work around it by nudging one matrix component by an invisible amount
+        # https://github.com/googlefonts/nanoemoji/issues/268
+        (
+            ("involutory_matrix.svg",),
+            "involutory_matrix_picosvg.ttx",
+            {"color_format": "picosvg"},
+        ),
     ],
 )
 def test_write_font_binary(svgs, expected_ttx, config_overrides):


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/268

Safari currently rejects a gradient if `gradientTransform` attribute contains a matrix whose inverse is equal to itself (aka [involutory matrix](https://en.wikipedia.org/wiki/Involutory_matrix)). These are perfectly valid, non-singular invertible transformations which happen to have an inverse which is equal to themselves (notably, reflection across x/y axis). Safari assumes they are non-invertible and incorrectly rejects the whole gradient. The [recommendation from the WebKit maintainer](https://github.com/litherum) is to hack the matrix by a small, invisible amount enough to trick Safari.
I heard this bug has already been fixed internally but will take time until it reaches all users. Until then, we have no choice but doing this.