### PR TITLE
use 'ccmp' feature for required ligature substitution

### DIFF
--- a/src/nanoemoji/features.py
+++ b/src/nanoemoji/features.py
@@ -20,14 +20,17 @@
 from nanoemoji.glyph import glyph_name
 
 
-def generate_fea(rgi_sequences):
-    # Generate rlig feature with ligature lookup for multi-codepoint RGIs
+DEFAULT_GSUB_FEATURE_TAG = "ccmp"
+
+
+def generate_fea(rgi_sequences, feature_tag=DEFAULT_GSUB_FEATURE_TAG):
+    # Generate feature with ligature lookup for multi-codepoint RGIs
     rules = []
     rules.append("languagesystem DFLT dflt;")
     rules.append("languagesystem latn dflt;")
     rules.append("")
 
-    rules.append("feature rlig {")
+    rules.append(f"feature {feature_tag} {{")
     for rgi in sorted(rgi_sequences):
         if len(rgi) == 1:
             continue
@@ -35,6 +38,6 @@ def generate_fea(rgi_sequences):
         target = glyph_name(rgi)
         rules.append("  sub %s by %s;" % (" ".join(glyphs), target))
 
-    rules.append("} rlig;")
+    rules.append(f"}} {feature_tag};")
     rules.append("")
     return "\n".join(rules)

--- a/tests/features_test.py
+++ b/tests/features_test.py
@@ -1,0 +1,19 @@
+from textwrap import dedent
+from nanoemoji.features import generate_fea, DEFAULT_GSUB_FEATURE_TAG
+import pytest
+
+
+@pytest.mark.parametrize("feature_tag", (DEFAULT_GSUB_FEATURE_TAG, "rlig"))
+def test_generate_fea(feature_tag):
+    rgi_sequences = [(0x1F64C,), (0x1F64C, 0x1F3FB), (0x1F64C, 0x1F3FC)]
+    assert generate_fea(rgi_sequences, feature_tag=feature_tag) == dedent(
+        f"""\
+        languagesystem DFLT dflt;
+        languagesystem latn dflt;
+
+        feature {feature_tag} {{
+          sub g_1f64c g_1f3fb by g_1f64c_1f3fb;
+          sub g_1f64c g_1f3fc by g_1f64c_1f3fc;
+        }} {feature_tag};
+        """
+    )


### PR DESCRIPTION
instead of 'rlig', for wider compatibility. NotoColorEmoji.ttf does the same
Fixes #279

