### PR TITLE
Bump fonttools 4.23.1 and update tests' expectations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "absl-py>=0.9.0",
         "dataclasses>=0.8; python_version < '3.7'",
-        "fonttools[ufo]>=4.22.0",
+        "fonttools[ufo]>=4.23.1",
         "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",

--- a/tests/linear_gradient_rect_colr_1.ttx
+++ b/tests/linear_gradient_rect_colr_1.ttx
@@ -100,9 +100,6 @@
         </Paint>
       </BaseGlyphV1Record>
     </BaseGlyphV1List>
-    <LayerV1List>
-      <!-- LayerCount=0 -->
-    </LayerV1List>
   </COLR>
 
   <CPAL>

--- a/tests/one_rect_transformed.ttx
+++ b/tests/one_rect_transformed.ttx
@@ -80,9 +80,6 @@
         </Paint>
       </BaseGlyphV1Record>
     </BaseGlyphV1List>
-    <LayerV1List>
-      <!-- LayerCount=0 -->
-    </LayerV1List>
   </COLR>
 
   <CPAL>

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -110,9 +110,6 @@
         </Paint>
       </BaseGlyphV1Record>
     </BaseGlyphV1List>
-    <LayerV1List>
-      <!-- LayerCount=0 -->
-    </LayerV1List>
   </COLR>
 
   <CPAL>


### PR DESCRIPTION
Latest fontTools.colorLib now sets LayerV1List attribute to None when empty, it's optional in CORLv1 (fonttools/fonttools#2308).