### PR TITLE
drop support for python 3.6, require >= 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - {platform: ubuntu-latest, python-version: 3.6}
           - {platform: ubuntu-latest, python-version: 3.7}
           - {platform: ubuntu-latest, python-version: 3.8}
           - {platform: ubuntu-latest, python-version: 3.9}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ nanoemoji --helpfull
 nanoemoji --color_format glyf_colr_1 $(find ../noto-emoji/svg -name 'emoji_u270d*.svg')
 ```
 
+Requires Python 3.7 or greater.
+
 ## Releasing
 
 See https://googlefonts.github.io/python#make-a-release.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "absl-py>=0.9.0",
-        "dataclasses>=0.8; python_version < '3.7'",
         "fonttools[ufo]>=4.23.1",
         "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
@@ -46,7 +45,8 @@ setup(
             "pytype==2020.11.23; python_version < '3.9'",
         ],
     },
-    python_requires=">=3.6",
+    # this is so we can use the built-in dataclasses module
+    python_requires=">=3.7",
 
     # this is for type checker to use our inline type hints:
     # https://www.python.org/dev/peps/pep-0561/#id18

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 ;   $ export TOXENV=py39
 ;   $ tox
 ;     # If present use $TOXENV environment variable
-envlist = lint, py3{6,7,8,9}
+envlist = lint, py3{7,8,9}
 
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error


### PR DESCRIPTION
Same as https://github.com/googlefonts/picosvg/pull/234