### PR TITLE
Use new Paint formats

### DIFF
--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -132,7 +132,10 @@ class PaintColrLayers(Paint):
             yield from p.colors()
 
     def to_ufo_paint(self, colors):
-        return [p.to_ufo_paint(colors) for p in self.layers]
+        return {
+            "Format": self.format,
+            "Layers": [p.to_ufo_paint(colors) for p in self.layers],
+        }
 
     def children(self):
         return self.layers
@@ -538,7 +541,7 @@ class PaintSkewAroundCenter(Paint):
         return (
             Affine2D.identity()
             .translate(self.center[0], self.center[1])
-            .skew(radians(self.xSkewAngle), radians(self.ySkewAngle))
+            .skew(-radians(self.xSkewAngle), radians(self.ySkewAngle))
             .translate(-self.center[0], -self.center[1])
         )
 

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -73,6 +73,12 @@ class CompositeMode(IntEnum):
     HSL_LUMINOSITY = 26
 
 
+_PAINT_FIELD_TO_OT_FIELD = {
+    "format": "PaintFormat",
+    "paint": "Paint",
+}
+
+
 @dataclasses.dataclass(frozen=True)
 class PaintTraverseContext:
     path: Tuple["Paint", ...]
@@ -120,6 +126,16 @@ class Paint:
     def gettransform(self) -> Affine2D:
         # Returns the transform caused by this Paint (not it's ancestors)
         return Affine2D.identity()
+
+    @classmethod
+    def from_ot(cls, ot_paint: ot.Paint) -> "Paint":
+        paint_t = globals()[ot_paint.getFormatName()]
+        paint_args = tuple(
+            getattr(ot_paint, _PAINT_FIELD_TO_OT_FIELD.get(f.name, f.name))
+            for f in dataclasses.fields(paint_t)
+        )
+        paint = paint_t(*paint_args)
+        return paint
 
 
 @dataclasses.dataclass(frozen=True)
@@ -568,3 +584,53 @@ class PaintComposite(Paint):
 
     def children(self) -> Iterable[Paint]:
         return (self.source, self.backdrop)
+
+
+def is_transform(paint_or_format) -> bool:
+    if isinstance(paint_or_format, Paint):
+        paint_or_format = paint_or_format.format
+    return (
+        ot.PaintFormat.PaintTransform
+        <= paint_or_format
+        <= ot.PaintFormat.PaintVarSkewAroundCenter
+    )
+
+
+def _int16_safe(*values):
+    return all(v == int(v) and v <= 32767 and v >= -32768 for v in values)
+
+
+def _f2dot14_safe(*values):
+    return all(value >= -2.0 and value < 2.0 for value in values)
+
+
+def _f2dot14_rotation_safe(*values):
+    return all((value / 180.0) >= -2.0 and (value / 180.0) < 2.0 for value in values)
+
+
+def transformed(transform: Affine2D, target: Paint) -> Paint:
+    if transform == Affine2D.identity():
+        return target
+
+    # Int16 translation?
+    translation, rest = transform.decompose_translation()
+    if translation != Affine2D.identity() and rest == Affine2D.identity():
+        dx, dy = transform.gettranslate()
+        if _int16_safe(dx, dy):
+            return PaintTranslate(paint=target, dx=dx, dy=dy)
+
+    # A wee scale?
+    scale, rest = transform.decompose_scale()
+    if scale != Affine2D.identity() and rest == Affine2D.identity():
+        sx, sy = transform.getscale()
+        if _f2dot14_safe(sx, sy):
+            if almost_equal(sx, sy):
+                return PaintScaleUniform(paint=target, scale=sx)
+            else:
+                return PaintScale(paint=target, scaleX=sx, scaleY=sy)
+
+    # TODO optimize rotations
+
+    # TODO optimize scale, skew, rotate around center
+
+    return PaintTransform(paint=target, transform=tuple(transform))

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -175,11 +175,8 @@ def _round_coords(paint, prec=5):
             r0=round(paint.r0, prec),
             r1=round(paint.r1, prec),
         )
-    if isinstance(paint, PaintTransform):
-        return dataclasses.replace(
-            paint,
-            transform=tuple(round(v, prec) for v in paint.transform),
-        )
+    if is_transform(paint):
+        return transformed(paint.gettransform().round(prec), paint.paint)
     return paint
 
 
@@ -250,8 +247,9 @@ def _round_coords(paint, prec=5):
             (
                 PaintGlyph(
                     glyph="M2,2 L8,2 L8,4 L2,4 L2,2 Z",
-                    paint=PaintTransform(
-                        transform=(1.0, 0.0, 0.0, 0.33333, 0.0, 0.0),
+                    paint=PaintScale(
+                        scaleX=1.0,
+                        scaleY=0.33333,
                         paint=PaintRadialGradient(
                             extend=Extend.REPEAT,
                             stops=(
@@ -408,8 +406,9 @@ def _round_coords(paint, prec=5):
                 ),
                 PaintGlyph(
                     glyph="M2,5 L8,5 L8,7 L2,7 L2,5 Z",
-                    paint=PaintTransform(
-                        transform=(1.0, 0.0, 0.0, 0.33333, 0, 0),
+                    paint=PaintScale(
+                        scaleX=1.0,
+                        scaleY=0.33333,
                         paint=PaintRadialGradient(
                             stops=(
                                 ColorStop(

--- a/tests/colr_to_svg.py
+++ b/tests/colr_to_svg.py
@@ -25,7 +25,7 @@ from nanoemoji.paint import (
     PaintColrGlyph,
     PaintComposite,
     PaintColrLayers,
-    PaintTransform,
+    is_transform,
 )
 from nanoemoji.svg import (
     _svg_matrix,
@@ -221,24 +221,9 @@ def _colr_v1_paint_to_svg(
         )
 
         _draw_svg_path(svg_path, glyph_set, layer_glyph, font_to_vbox)
-    elif ot_paint.Format == PaintTransform.format:
-        transform = Affine2D.compose_ltr(
-            (
-                (
-                    Affine2D.identity()
-                    if not ot_paint.Transform
-                    else Affine2D(
-                        ot_paint.Transform.xx,
-                        ot_paint.Transform.yx,
-                        ot_paint.Transform.xy,
-                        ot_paint.Transform.yy,
-                        ot_paint.Transform.dx,
-                        ot_paint.Transform.dy,
-                    )
-                ),
-                transform,
-            )
-        )
+    elif is_transform(ot_paint.Format):
+        paint = Paint.from_ot(ot_paint)
+        transform @= paint.gettransform()
         _colr_v1_paint_to_svg(
             ttfont,
             glyph_set,

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -70,7 +70,7 @@
       <BaseGlyphPaintRecord index="0">
         <BaseGlyph value="e000"/>
         <Paint Format="10"><!-- PaintGlyph -->
-          <Paint Format="12"><!-- PaintTransform -->
+          <Paint Format="16"><!-- PaintScale -->
             <Paint Format="6"><!-- PaintRadialGradient -->
               <ColorLine>
                 <Extend value="repeat"/>
@@ -93,14 +93,8 @@
               <y1 value="210"/>
               <r1 value="30"/>
             </Paint>
-            <Transform>
-              <xx value="1.0"/>
-              <yx value="0.0"/>
-              <xy value="0.0"/>
-              <yy value="0.33333"/>
-              <dx value="0.0"/>
-              <dy value="0.0"/>
-            </Transform>
+            <scaleX value="1.0"/>
+            <scaleY value="0.3333"/>
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>

--- a/tests/radial_gradient_rect_from_colr_1.svg
+++ b/tests/radial_gradient_rect_from_colr_1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
   <defs>
-    <radialGradient id="g1" cx="5" cy="9" r="3" gradientUnits="userSpaceOnUse" spreadMethod="repeat" gradientTransform="matrix(1 0 0 0.333 0 0)">
+    <radialGradient id="g1" cx="5" cy="9.002" r="3" gradientUnits="userSpaceOnUse" spreadMethod="repeat" gradientTransform="matrix(1 0 0 0.333 0 0)">
       <stop offset="0.05" stop-color="fuchsia"/>
       <stop offset="0.75" stop-color="orange"/>
     </radialGradient>

--- a/tests/rect_colr_1.ttx
+++ b/tests/rect_colr_1.ttx
@@ -84,7 +84,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="12"><!-- PaintTransform -->
+      <Paint index="1" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="0"/>
@@ -92,14 +92,8 @@
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <Transform>
-          <xx value="1.0"/>
-          <yx value="0.0"/>
-          <xy value="0.0"/>
-          <yy value="1.0"/>
-          <dx value="20.0"/>
-          <dy value="-20.0"/>
-        </Transform>
+        <dx value="20"/>
+        <dy value="-20"/>
       </Paint>
     </LayerList>
   </COLR>

--- a/tests/rects_colr_1.ttx
+++ b/tests/rects_colr_1.ttx
@@ -103,7 +103,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="1" Format="12"><!-- PaintTransform -->
+      <Paint index="1" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="0"/>
@@ -111,14 +111,8 @@
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <Transform>
-          <xx value="1.0"/>
-          <yx value="0.0"/>
-          <xy value="0.0"/>
-          <yy value="1.0"/>
-          <dx value="20.0"/>
-          <dy value="-20.0"/>
-        </Transform>
+        <dx value="20"/>
+        <dy value="-20"/>
       </Paint>
       <Paint index="2" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
@@ -127,7 +121,7 @@
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="3" Format="12"><!-- PaintTransform -->
+      <Paint index="3" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="1"/>
@@ -135,14 +129,8 @@
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <Transform>
-          <xx value="1.0"/>
-          <yx value="0.0"/>
-          <xy value="0.0"/>
-          <yy value="1.0"/>
-          <dx value="20.0"/>
-          <dy value="-20.0"/>
-        </Transform>
+        <dx value="20"/>
+        <dy value="-20"/>
       </Paint>
     </LayerList>
   </COLR>


### PR DESCRIPTION
First steps toward using the new paint formats. Only int16 translate and scale are converted. Builds on #310's update to FT 4.5.2; should merge that first. Until merged may wish to view diff via https://github.com/googlefonts/nanoemoji/compare/ft_452...reduce_prec.

Some rounding seems to occur due to changes in FontTools, for example `'scaleY': 0.333333333` ends up rounded to 0.3333 instead of 0.3333**3**. Presumably this is due to the move from Fixed to F2Dot14.
