### PR TITLE
Avoid kerploding due to Affine2x3's that are outside Fixed range.

### DIFF
--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -266,7 +266,6 @@ class GlyphReuseCache:
         assert path.startswith("M"), f"{path} doesn't look like a path"
 
         if self._config.reuse_tolerance == -1:
-            print("reuse disabled")
             return None
 
         norm_path = normalize(SVGPath(d=path), self._config.reuse_tolerance).d

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -303,3 +303,28 @@ def test_ufo_color_base_glyph_bounds(svgs, config_overrides, expected):
     else:
         assert bounds is None
         assert len(base_glyph) == 0
+
+
+# Not try to fully exercise affine_between, just to sanity check things somewhat work
+@pytest.mark.parametrize(
+    "path_a, path_b, expected_result",
+    [
+        (
+            "M-1,-1 L 0,1 L 1, -1 z",
+            "M-2,-2 L 0,2 L 2, -2 z",
+            write_font.ReuseResult(
+                glyph_name="A", transform=Affine2D.identity().scale(2)
+            ),
+        ),
+        # https://github.com/googlefonts/nanoemoji/issues/313
+        (
+            "M818.7666015625,133.60003662109375 C818.7666015625,130.28631591796875 816.080322265625,127.5999755859375 812.7666015625,127.5999755859375 C809.4529418945312,127.5999755859375 806.7666015625,130.28631591796875 806.7666015625,133.60003662109375 C806.7666015625,136.9136962890625 809.4529418945312,139.60003662109375 812.7666015625,139.60003662109375 C816.080322265625,139.60003662109375 818.7666015625,136.9136962890625 818.7666015625,133.60003662109375 Z",
+            "M1237.5,350 C1237.5,18.629150390625 968.870849609375,-250 637.5,-250 C306.1291198730469,-250 37.5,18.629150390625 37.5,350 C37.5,681.370849609375 306.1291198730469,950 637.5,950 C968.870849609375,950 1237.5,681.370849609375 1237.5,350 Z",
+            None,
+        ),
+    ],
+)
+def test_glyph_reuse_cache(path_a, path_b, expected_result):
+    reuse_cache = write_font.GlyphReuseCache(_DEFAULT_CONFIG)
+    reuse_cache.add_glyph("A", path_a)
+    assert reuse_cache.try_reuse(path_b) == expected_result


### PR DESCRIPTION
Short-term fix to prevent crash. Hoping to later improve the way we go about building glyphs to reduce frequency.