### PR TITLE
Fix bounding box incorrectly computed with reflection affine transform

### DIFF
--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -23,7 +23,7 @@ import csv
 import dataclasses
 import math
 from fontTools import ttLib
-from fontTools.misc.arrayTools import rectArea, unionRect
+from fontTools.misc.arrayTools import rectArea, normRect, unionRect
 from fontTools.misc.roundTools import otRound
 from fontTools.ttLib.tables import otTables as ot
 from itertools import chain
@@ -475,8 +475,12 @@ def _bounds(
             glyph_bbox = glyph.getControlBounds(color_glyph.ufo)
             if glyph_bbox is None:
                 continue
-            glyph_bbox = tuple(context.transform.map_point(glyph_bbox[:2])) + tuple(
-                context.transform.map_point(glyph_bbox[2:])
+            # transform may flip x and/or y thus we need to normalize the bounding
+            # rectangle such that {x,y}Min <= {x,y}Max holds true
+            # https://github.com/googlefonts/nanoemoji/issues/335
+            glyph_bbox = normRect(
+                tuple(context.transform.map_point(glyph_bbox[:2]))
+                + tuple(context.transform.map_point(glyph_bbox[2:]))
             )
             if bounds is None:
                 bounds = glyph_bbox

--- a/tests/flipped_reused_shape.svg
+++ b/tests/flipped_reused_shape.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+	<path d="m0,0 l50,100 h-50 z" fill="green"/>
+	<path d="m100,0 l-50,100 h50 z" fill="red"/>
+</svg>

--- a/tests/transformed_components_overlap.ttx
+++ b/tests/transformed_components_overlap.ttx
@@ -137,7 +137,7 @@
           <xMin value="38"/>
           <yMin value="34"/>
           <xMax value="42"/>
-          <yMax value="72"/>
+          <yMax value="76"/>
         </ClipBox>
       </Clip>
     </ClipList>

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -312,6 +312,16 @@ def test_write_font_binary(svgs, expected_ttx, config_overrides):
             {},
             None,
         ),
+        (
+            # this SVG contains two triangles flipped vertically around the middle,
+            # with each triangle's bbox half-viewbox wide; the union of their bboxes
+            # encompasses the full extent of the upem/viewbox.
+            # Reflection may play tricks if the bbox doesn't get normalized, cf.
+            # https://github.com/googlefonts/nanoemoji/issues/335
+            ("flipped_reused_shape.svg",),
+            {},
+            (0, 0, 100, 100),
+        ),
     ],
 )
 def test_ufo_color_base_glyph_bounds(svgs, config_overrides, expected):


### PR DESCRIPTION
Fixes https://github.com/googlefonts/nanoemoji/issues/335

I first add a test to reproduce the bug, then follow up with the actual fix