### PR TITLE
Fix computing bounding box for rotated reused shapes

### DIFF
--- a/tests/rotated_bounds_1.svg
+++ b/tests/rotated_bounds_1.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000">
+  <path d="M100,500 L500,100 L900,500 L500,900 Z"/>
+</svg>

--- a/tests/rotated_bounds_2.svg
+++ b/tests/rotated_bounds_2.svg
@@ -1,0 +1,5 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1000 1000">
+  <g transform="matrix(0.707107 0.707107 -0.707107 0.707107 500 -207.106781)">
+    <path d="M100,500 L500,100 L900,500 L500,900 Z" fill="red" opacity="0.5"/>
+  </g>
+</svg>

--- a/tests/transformed_components_overlap.ttx
+++ b/tests/transformed_components_overlap.ttx
@@ -137,7 +137,7 @@
           <xMin value="38"/>
           <yMin value="34"/>
           <xMax value="42"/>
-          <yMax value="76"/>
+          <yMax value="74"/>
         </ClipBox>
       </Clip>
     </ClipList>


### PR DESCRIPTION
Fixes #341 

I'll add the (failing) test case first, then follow up with the fix