### PR TITLE
fix a couple of bugs in tools/colr2svg.py script 

### DIFF
--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -91,6 +91,7 @@ _PAINT_FIELD_TO_OT_FIELD = {
     "format": ("PaintFormat", _identity),
     "paint": ("Paint", _identity),
     "transform": ("Transform", lambda t: (t.xx, t.yx, t.xy, t.yy, t.dx, t.dy)),
+    "center": (("centerX", "centerY"), _identity),
 }
 
 
@@ -152,7 +153,11 @@ class Paint:
             ot_field, converter = _PAINT_FIELD_TO_OT_FIELD.get(
                 f.name, (f.name, _identity)
             )
-            paint_args.append(converter(getattr(ot_paint, ot_field)))
+            if isinstance(ot_field, tuple):
+                arg = tuple(converter(getattr(ot_paint, f)) for f in ot_field)
+            else:
+                arg = converter(getattr(ot_paint, ot_field))
+            paint_args.append(arg)
         paint = paint_t(*paint_args)
         return paint
 

--- a/tests/colr_to_svg.py
+++ b/tests/colr_to_svg.py
@@ -272,7 +272,6 @@ def _colr_v1_glyph_to_svg(
     glyph_set: ttLib.ttFont._TTGlyphSet,
     view_box: Rect,
     glyph: otTables.BaseGlyphRecord,
-    reuse_cache: ReuseCache,
 ) -> etree.Element:
     glyph_set = ttfont.getGlyphSet()
     svg_root = _svg_root(view_box)
@@ -281,6 +280,7 @@ def _colr_v1_glyph_to_svg(
     descender = ttfont["OS/2"].sTypoDescender
     width = ttfont["hmtx"][glyph.BaseGlyph][0]
     font_to_vbox = _map_font_space_to_viewbox(view_box, ascender, descender, width)
+    reuse_cache = _new_reuse_cache()
     _colr_v1_paint_to_svg(
         ttfont, glyph_set, svg_root, svg_defs, font_to_vbox, glyph.Paint, reuse_cache
     )
@@ -303,12 +303,9 @@ def _colr_v0_to_svgs(view_box: Rect, ttfont: ttLib.TTFont) -> Dict[str, SVG]:
 
 def _colr_v1_to_svgs(view_box: Rect, ttfont: ttLib.TTFont) -> Dict[str, SVG]:
     glyph_set = ttfont.getGlyphSet()
-    reuse_cache = _new_reuse_cache()
     return {
         g.BaseGlyph: SVG.fromstring(
-            etree.tostring(
-                _colr_v1_glyph_to_svg(ttfont, glyph_set, view_box, g, reuse_cache)
-            )
+            etree.tostring(_colr_v1_glyph_to_svg(ttfont, glyph_set, view_box, g))
         )
         for g in ttfont["COLR"].table.BaseGlyphList.BaseGlyphPaintRecord
     }


### PR DESCRIPTION
with this, I can fully convert all the glyphs from noto_emoji-glyf_colr_1.ttf to SVG files using the tools/colr2svg.py script.
See commit message for details