### PR TITLE
Compute reuse on the svg path; seems to increase odds of success

### DIFF
--- a/src/nanoemoji/glyph_reuse.py
+++ b/src/nanoemoji/glyph_reuse.py
@@ -47,7 +47,7 @@ class GlyphReuseCache:
         """Try to reproduce path as the transformation of another glyph.
 
         Returns (glyph name, transform) if possible, None if not.
-        """        
+        """
         assert (
             not path in self._known_glyphs
         ), f"{path} isn't a path, it's a glyph name we've seen before"
@@ -68,18 +68,24 @@ class GlyphReuseCache:
                 SVGPath(d=glyph_path), SVGPath(d=path), self._reuse_tolerance
             )
 
-            # TEMPORARY
-            if affine is None:
-                affine = None
+            if affine == Affine2D.identity():
+                logging.info(f"We can reuse {glyph_name} unmodified!")
 
             if affine is None:
-                logging.warning("affine_between failed: \n\t<path d=\"%s\"/>\n\t<path d=\"%s\"/> ", glyph_path, path)
+                logging.warning(
+                    'affine_between failed: \n\t<path d="%s"/>\n\t<path d="%s"/> ',
+                    glyph_path,
+                    path,
+                )
                 continue
 
             # https://github.com/googlefonts/nanoemoji/issues/313 avoid out of bounds affines
             if not fixed_safe(*affine):
                 logging.warning(
-                    "affine_between overflows Fixed: \n\t<path d=\"%s\"/>\n\t<path d=\"%s\"/>\n\t%s", glyph_path, path, affine
+                    'affine_between overflows Fixed: \n\t<path d="%s"/>\n\t<path d="%s"/>\n\t%s',
+                    glyph_path,
+                    path,
+                    affine,
                 )
                 continue
 

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -727,8 +727,10 @@ def is_gradient(paint_or_format) -> bool:
 
 
 def transformed(transform: Affine2D, target: Paint) -> Paint:
-    if transform == Affine2D.identity():
+    if Affine2D.identity().almost_equals(transform):
+        logging.info("  transform is nop")
         return target
+    logging.info("  transform is real %s", transform)
 
     sx, b, c, sy, dx, dy = transform
 

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -280,11 +280,17 @@ def _migrate_paths_to_ufo_glyphs(
         # The odds of finding reuse in svg space seems to be much higher. Not completely sure why.
         reuse_result = glyph_cache.try_reuse(path_in_svg_space)
         if reuse_result is not None:
-            reuse_transform = Affine2D.compose_ltr((
-                svg_units_to_font_units.inverse(),
-                reuse_result.transform,
-                svg_units_to_font_units,
-            ))
+            if reuse_result.transform != Affine2D.identity():
+                reuse_transform = Affine2D.compose_ltr(
+                    (
+                        svg_units_to_font_units.inverse(),
+                        reuse_result.transform,
+                        svg_units_to_font_units,
+                    )
+                )
+            else:
+                reuse_transform = reuse_result.transform
+
             # TODO: when is it more compact to use a new transforming glyph?
             child_transform = Affine2D.identity()
             child_paint = paint.paint

--- a/src/nanoemoji/write_glyphgraph.py
+++ b/src/nanoemoji/write_glyphgraph.py
@@ -192,7 +192,7 @@ def _additional_log(font, paint):
         glyph_set = font.getGlyphSet()
         svg_pen = SVGPathPen(glyph_set)
         glyph_set[glyph_name].draw(svg_pen)
-        return " " + f"<path d=\"{svg_pen.getCommands()}\" />"
+        return " " + f'<path d="{svg_pen.getCommands()}" />'
     return ""
 
 

--- a/src/nanoemoji/write_glyphgraph.py
+++ b/src/nanoemoji/write_glyphgraph.py
@@ -156,6 +156,14 @@ def _paint_node(glyph_order, palette, paint) -> Node:
             paint.Glyph,
         )
         return Node(node_id="_".join(id_parts))
+    if paint.Format == ot.PaintFormat.PaintTranslate:
+        id_parts = (
+            "Translate",
+            f"dx {paint.dx}",
+            f"dy {paint.dy}",
+            _paint_node(glyph_order, palette, paint.Paint).node_id,
+        )
+        return Node(node_id="_".join(id_parts))
     if paint.Format == ot.PaintFormat.PaintTransform:
         id_parts = (
             "Transform",
@@ -222,6 +230,8 @@ def _paint(dag, parent, font, paint, depth):
         # adding format 5 edges makes the result a horrible mess
         # elif paint.Format == 5:
         #   _glyph(dag, node_id, font, _only(_base_glyphs(font, lambda g: g.BaseGlyph == paint.Glyph)), depth + 1)
+        elif paint.Format == ot.PaintFormat.PaintTranslate:
+            _paint(dag, node_id, font, paint.Paint, depth + 1)
         elif paint.Format == ot.PaintFormat.PaintTransform:
             _paint(dag, node_id, font, paint.Paint, depth + 1)
         elif paint.Format == ot.PaintFormat.PaintComposite:

--- a/tools/about_size.py
+++ b/tools/about_size.py
@@ -1,0 +1,52 @@
+from about_paint import traverse_paint
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables import otTables as ot
+import os
+import sys
+
+
+def _extra_glyf(font, glyf):
+    return f"{len(font.getGlyphOrder())} glyphs"
+
+
+def _glyphs_in_COLR(colr):
+    glyphs = set()
+
+    visited = set()
+    def _traverse_callback(paint):
+        if paint.Format == ot.PaintFormat.PaintGlyph:
+            glyphs.add(paint.Glyph)
+
+    traverse_paint(colr, _traverse_callback)
+
+    return glyphs
+
+
+def _extra_COLR(font, colr):
+    colr = colr.table
+    glyphs = _glyphs_in_COLR(colr)
+    return f"{len(glyphs)} glyphs"
+
+
+
+
+assert len(sys.argv) == 2
+font = TTFont(sys.argv[1], lazy=False)
+
+file_size = os.stat(sys.argv[1]).st_size
+
+for tag in font.keys():
+    if len(tag) != 4:
+        continue
+    table_size = len(font.reader[tag])
+    table_pct = 100. * table_size / file_size
+
+    extra = globals().get(f"_extra_{tag.strip()}", lambda *_: "")(font, font[tag])
+
+    print(f"{tag} {table_size:>6} {table_pct: >4.0f} {extra}")
+
+colr = font["COLR"].table
+colr_data = font.reader["COLR"]
+
+
+


### PR DESCRIPTION
DO NOT SUBMIT; needs a test that previously didn't find reuse and now does. Tested with https://github.com/googlefonts/picosvg/pull/245 applied.

Example:

```
nanoemoji ~/oss/color-fonts/font-srcs/noto-emoji/svg/emoji_u1f610.svg

# before [more glyphs / less COLR], 1556 bytes
tag   size   pct
head     54    3 
hhea     36    2 
maxp     32    2 
OS/2     96    6 
hmtx     24    2 
cmap    108    7 
loca     22    1 
glyf    402   26 10 glyphs
name    300   19 
post     32    2 
COLR    197   13 7 glyphs
CPAL     38    2

# after [fewer glyphs / more COLR], 1508 bytes
tag   size   pct
head     54    4 
hhea     36    2 
maxp     32    2 
OS/2     96    6 
hmtx     20    1 
cmap    108    7 
loca     18    1 
glyf    304   20 8 glyphs
name    300   20 
post     32    2 
COLR    259   17 5 glyphs
CPAL     38    3
```