### PR TITLE
remove unused --output flag, format depends on output_file extension suffix

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -65,9 +65,6 @@ flags.DEFINE_enum(
     sorted(_COLOR_FORMATS),
     "Type of font to generate.",
 )
-flags.DEFINE_enum(
-    "output", None, ["ufo", "font"], "Whether to output a font binary or a UFO."
-)
 flags.DEFINE_bool(
     "keep_glyph_names", None, "Whether or not to store glyph names in the font."
 )
@@ -140,7 +137,6 @@ class FontConfig(NamedTuple):
     keep_glyph_names: bool = False
     clip_to_viewbox: bool = True
     clipbox_quantization: Optional[int] = None
-    output: str = "font"
     fea_file: str = "features.fea"
     codepointmap_file: str = "codepointmap.csv"
     pretty_print: bool = False
@@ -199,7 +195,6 @@ def write(dest: Path, config: FontConfig):
         "pretty_print": config.pretty_print,
         "fea_file": config.fea_file,
         "codepointmap_file": config.codepointmap_file,
-        "output": config.output,
         "axis": {
             a.axisTag: {
                 "name": a.name,
@@ -284,7 +279,6 @@ def load(
     pretty_print = _pop_flag(config, "pretty_print")
     fea_file = _pop_flag(config, "fea_file")
     codepointmap_file = _pop_flag(config, "codepointmap_file")
-    output = _pop_flag(config, "output")
 
     axes = []
     for axis_tag, axis_config in config.pop("axis").items():
@@ -361,7 +355,6 @@ def load(
         clip_to_viewbox=clip_to_viewbox,
         clipbox_quantization=clipbox_quantization,
         pretty_print=pretty_print,
-        output=output,
         fea_file=fea_file,
         codepointmap_file=codepointmap_file,
         axes=tuple(axes),

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -356,9 +356,7 @@ def _update_sources(font_config: FontConfig) -> FontConfig:
 def write_ufo_build(
     nw: ninja_syntax.Writer, font_config: FontConfig, master: MasterConfig
 ):
-    ufo_config = font_config._replace(
-        output_file=master.output_ufo, output="ufo", masters=(master,)
-    )
+    ufo_config = font_config._replace(output_file=master.output_ufo, masters=(master,))
     ufo_config = _update_sources(ufo_config)
     config.write(build_dir() / _ufo_config(font_config, master), ufo_config)
     nw.build(

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -340,7 +340,7 @@ def test_write_font_binary(svgs, expected_ttx, config_overrides):
     ],
 )
 def test_ufo_color_base_glyph_bounds(svgs, config_overrides, expected_clip_boxes):
-    config_overrides = {"output": "ufo", **config_overrides}
+    config_overrides = {"output_file": "font.ufo", **config_overrides}
     config, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
     ufo, _ = write_font._generate_color_font(config, glyph_inputs)
 


### PR DESCRIPTION
initially we had an --output flag to say whether to output a font binary or a UFO, but at some point we switched to determining that by looking at the --output_file's extension suffix (e.g. ".ufo", or ".ttf" or ".otf"). I.e. see:

https://github.com/googlefonts/nanoemoji/blob/07dd99e7ed4a56831e0a9d5070b1b6ea19581ead/src/nanoemoji/config.py#L151-L153

and also search "config.output_format" in `src/nanoemoji/write_font.py` module to example.

Since the old --output flag is now unused and serves no purpose, it makes sense to remove it altogether.