### PR TITLE
Suport writing a font with COLRv1 *and* ot-svg

### DIFF
--- a/src/nanoemoji/colors.py
+++ b/src/nanoemoji/colors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+from typing import Optional, Tuple
 
 # See https://www.w3.org/TR/css-color-4/#named-colors
 # Chrome DevTools:
@@ -173,11 +174,11 @@ def css_colors():
     return _CSS_COLORS
 
 
-def css_color(name):
+def css_color(name) -> Optional[Tuple[int, int, int]]:
     return _CSS_COLORS.get(name, None)
 
 
-def color_name(rgb):
+def color_name(rgb) -> Optional[str]:
     for name, value in _CSS_COLORS.items():
         if value == rgb:
             return name
@@ -186,7 +187,7 @@ def color_name(rgb):
 
 class Color(collections.namedtuple("Color", "red green blue alpha")):
     @classmethod
-    def fromstring(cls, s, alpha=1.0):
+    def fromstring(cls, s, alpha=1.0) -> "Color":
         # https://www.w3.org/TR/css-color-4/#hex-notation
         s = s.strip()
         if s.startswith("#"):
@@ -218,7 +219,7 @@ class Color(collections.namedtuple("Color", "red green blue alpha")):
             raise ValueError(f"invalid or unsupported color string: {s!r}")
         return cls(red, green, blue, alpha)
 
-    def to_ufo_color(self):
+    def to_ufo_color(self) -> Tuple[float, float, float, float]:
         # UFO stores colors as RGBA tuples of decimal [0..1] floats. Here we round to 3
         # decimal digits, which are sufficient to round-trip Fixed0.8 numbers
         return (
@@ -228,10 +229,10 @@ class Color(collections.namedtuple("Color", "red green blue alpha")):
             self.alpha,
         )
 
-    def opaque(self):
+    def opaque(self) -> "Color":
         return self._replace(alpha=1.0)
 
-    def to_string(self):
+    def to_string(self) -> str:
         # A CSS or SVG friendly string
         rgb = self[0:3]
         string = None

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -34,6 +34,7 @@ _COLOR_FORMATS = [
     "glyf",
     "glyf_colr_0",
     "glyf_colr_1",
+    "glyf_colr_1_and_picosvgz",
     "cff_colr_0",
     "cff_colr_1",
     "cff2_colr_0",

--- a/tests/rect_glyf_colr_1_and_picosvgz.ttx
+++ b/tests/rect_glyf_colr_1_and_picosvgz.ttx
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".space"/>
+    <GlyphID id="2" name="e000"/>
+    <GlyphID id="3" name="e000.0"/>
+  </GlyphOrder>
+
+  <hmtx>
+    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".space" width="100" lsb="0"/>
+    <mtx name="e000" width="100" lsb="0"/>
+    <mtx name="e000.0" width="100" lsb="20"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name=".space"/><!-- SPACE -->
+      <map code="0xe000" name="e000"/><!-- ???? -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name=".space"/><!-- contains no outline data -->
+
+    <TTGlyph name="e000"/><!-- contains no outline data -->
+
+    <TTGlyph name="e000.0" xMin="20" yMin="60" xMax="80" yMax="80">
+      <contour>
+        <pt x="20" y="80" on="1"/>
+        <pt x="20" y="60" on="1"/>
+        <pt x="80" y="60" on="1"/>
+        <pt x="80" y="80" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=1 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="e000"/>
+        <Paint Format="1"><!-- PaintColrLayers -->
+          <NumLayers value="2"/>
+          <FirstLayerIndex value="0"/>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+    <LayerList>
+      <!-- LayerCount=2 -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="0"/>
+          <Alpha value="1.0"/>
+        </Paint>
+        <Glyph value="e000.0"/>
+      </Paint>
+      <Paint index="1" Format="14"><!-- PaintTranslate -->
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="2"><!-- PaintSolid -->
+            <PaletteIndex value="0"/>
+            <Alpha value="0.8"/>
+          </Paint>
+          <Glyph value="e000.0"/>
+        </Paint>
+        <dx value="20"/>
+        <dy value="-20"/>
+      </Paint>
+    </LayerList>
+    <ClipList Format="1">
+      <Clip>
+        <Glyph value="e000"/>
+        <ClipBox Format="1">
+          <xMin value="20"/>
+          <yMin value="40"/>
+          <xMax value="100"/>
+          <yMax value="80"/>
+        </ClipBox>
+      </Clip>
+    </ClipList>
+  </COLR>
+
+  <CPAL>
+    <version value="0"/>
+    <numPaletteEntries value="1"/>
+    <palette index="0">
+      <color index="0" value="#0000FFFF"/>
+    </palette>
+  </CPAL>
+
+  <SVG>
+
+    <svgDoc endGlyphID="3" startGlyphID="3">
+      <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+  <defs>
+    <path d="M2,2 L8,2 L8,4 L2,4 L2,2 Z" id="e000.0" fill="blue"/>
+  </defs>
+  <g id="glyph3" transform="matrix(10 0 0 10 0 -100)">
+    <use xlink:href="#e000.0"/>
+    <use xlink:href="#e000.0" x="2" y="2" opacity="0.8"/>
+  </g>
+</svg>
+]]>
+    </svgDoc>
+  </SVG>
+
+</ttFont>

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -279,6 +279,11 @@ def test_vertical_metrics(ascender, descender, linegap):
             "reuse_shape_varying_fill.ttx",
             {"color_format": "picosvg", "pretty_print": True},
         ),
+        (
+            ("rect.svg",),
+            "rect_glyf_colr_1_and_picosvgz.ttx",
+            {"color_format": "glyf_colr_1_and_picosvgz", "pretty_print": True},
+        ),
     ],
 )
 def test_write_font_binary(svgs, expected_ttx, config_overrides):


### PR DESCRIPTION
Avoid mutating the original copy of color_glyphs. This makes gluing an svg table onto a COLRv1 font kind of Just Work.

Fixes #260