### PR TITLE
be more careful when reordering SVG color glyphs

### DIFF
--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -565,17 +565,16 @@ def _ensure_groups_grouped_in_glyph_order(
     # font's current glyph order: i.e. we assume all color glyphs are placed in a
     # continuous block starting at the first color glyph.
     current_glyph_order = ttfont.getGlyphOrder()
-    first_color_gid = min(g.glyph_id for g in color_glyphs.values())
-    current_color_glyph_names = current_glyph_order[
-        first_color_gid : first_color_gid + len(color_glyph_order)
-    ]
+    min_color_gid = min(g.glyph_id for g in color_glyphs.values())
+    max_color_gid = max(g.glyph_id for g in color_glyphs.values())
+    current_color_glyph_names = current_glyph_order[min_color_gid : max_color_gid + 1]
     assert len(color_glyph_order) == len(current_color_glyph_names)
     rename_map = {
         color_glyph_order[i]: current_color_glyph_names[i]
         for i in range(len(color_glyph_order))
     }
 
-    glyph_order = current_glyph_order[:first_color_gid]
+    glyph_order = current_glyph_order[:min_color_gid]
     gid = len(glyph_order)
     for group in reuse_groups:
         for glyph_name in group:

--- a/tests/rect_glyf_colr_1_and_picosvgz.ttx
+++ b/tests/rect_glyf_colr_1_and_picosvgz.ttx
@@ -112,12 +112,12 @@
   </CPAL>
 
   <SVG>
-    <svgDoc endGlyphID="3" startGlyphID="3">
+    <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
     <path d="M2,2 L8,2 L8,4 L2,4 L2,2 Z" id="e000.0" fill="blue"/>
   </defs>
-  <g id="glyph3" transform="matrix(10 0 0 10 0 -100)">
+  <g id="glyph2" transform="matrix(10 0 0 10 0 -100)">
     <use xlink:href="#e000.0"/>
     <use xlink:href="#e000.0" x="2" y="2" opacity="0.8"/>
   </g>


### PR DESCRIPTION
don't simply assume they are always all at the end of the glyph order. For mixed COLR+SVG fonts, there may be additional layer glyphs after the block of base color glyphs.

Note how the expected test .ttx file had the wrong glyph index for the SVG color glyph: it was pointing to glyph 3 "e000.0" which is in fact one of the COLR layer glyphs, instead of glyph 2 "e000", the correct base color glyph.
 
Fixes #260