### PR TITLE
workaround for Skia bug whereby linear gradient's P2 has no effect

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -137,9 +137,17 @@ def _parse_linear_gradient(
         config, grad_el, shape_bbox, view_box, glyph_width
     )
 
-    return PaintLinearGradient(  # pytype: disable=wrong-arg-types
+    paint = PaintLinearGradient(  # pytype: disable=wrong-arg-types
         p0=p0, p1=p1, p2=p2, **common_args
     ).apply_transform(transform)
+
+    # At some point, skewed linear gradients stopped working in Skia,
+    # P2 having no effect: https://bugs.chromium.org/p/skia/issues/detail?id=12822
+    # For a bit, we'll play safe and 'rectify' the gradient such that the gradient
+    # look the same whether or not P2 is taken into account.
+    # TODO(anthrotype): Remove this once the bug fix has rolled out in Chrome.
+    assert isinstance(paint, PaintLinearGradient)
+    return paint.normalize()
 
 
 def _parse_radial_gradient(

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -241,19 +241,9 @@ def _define_linear_gradient(
     gradient = etree.SubElement(svg_defs, "linearGradient")
     gradient_id = gradient.attrib["id"] = f"g{len(svg_defs)}"
 
-    p0, p1, p2 = paint.p0, paint.p1, paint.p2
-    # P2 allows to rotate the linear gradient independently of the end points P0 and P1.
-    # Below we compute P3 which is the orthogonal projection of P1 onto a line passing
-    # through P0 and perpendicular to the "normal" or "rotation vector" from P0 and P2.
-    # The vector P3-P0 is the "effective" linear gradient vector after this rotation.
-    # When vector P2-P0 is perpendicular to the gradient vector P1-P0, then P3
-    # (projection of P1 onto perpendicular to normal) is == P1 itself thus no rotation.
-    # When P2 is collinear to the P1-P0 gradient vector, then this projected P3 == P0
-    # and the gradient degenerates to a solid paint (the last color stop).
-    p3 = p0 + (p1 - p0).projection((p2 - p0).perpendicular())
-
-    x1, y1 = p0
-    x2, y2 = p3
+    paint = paint.normalize()
+    x1, y1 = paint.p0
+    x2, y2 = paint.p1
     gradient.attrib["x1"] = _ntos(x1)
     gradient.attrib["y1"] = _ntos(y1)
     gradient.attrib["x2"] = _ntos(x2)

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -283,7 +283,7 @@ def _round_coords(paint, prec=5):
                             ColorStop(stopOffset=1.0, color=Color.fromstring("red")),
                         ),
                         p0=Point(x=0, y=1000),
-                        p1=Point(x=1000, y=1000),
+                        p1=Point(x=500, y=500),
                         p2=Point(x=-1000, y=0),
                     ),
                 ),


### PR DESCRIPTION
because of a regression in Skia, skewed linear gradients (i.e. where P2 is not perpendicular to P1-P0 vector) don't render correctly in Chrome. The position of rotation point P2 has no effect and the gradient never gets rotated.

See upstream issues:
https://skia-review.googlesource.com/c/skia/+/494676
https://bugs.chromium.org/p/chromium/issues/detail?id=1287162

As workaround, here we normalize the linear gradients so that they will look the same whether or not P2 is taken into account, by setting P1 to its projection onto the line perpendicular to the rotation vector.
We can remove this once the bug is fixed in Chrome.

