### PR TITLE
use abspath instead of Path.resolve() so symlinks aren't resolved

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -24,6 +24,8 @@ from picosvg.svg_transform import Affine2D
 import toml
 from typing import Any, Iterable, MutableMapping, NamedTuple, Optional, Tuple, Sequence
 
+from nanoemoji import util
+
 
 FLAGS = flags.FLAGS
 
@@ -322,7 +324,7 @@ def load(
                 srcs.update(_resolve_src(config_dir, src))
         if additional_srcs is not None:
             srcs.update(additional_srcs)
-        srcs = tuple(sorted(p.resolve() for p in srcs))
+        srcs = tuple(sorted(util.abspath(p) for p in srcs))
 
         master = MasterConfig(
             master_name,

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -33,7 +33,7 @@ from absl import logging
 import glob
 from nanoemoji import codepoints, config, write_font
 from nanoemoji.config import AxisPosition, FontConfig, MasterConfig
-from nanoemoji.util import fs_root, rel, only
+from nanoemoji.util import fs_root, rel, only, abspath
 from ninja import ninja_syntax
 import os
 from pathlib import Path
@@ -265,7 +265,7 @@ def picosvg_dest(clipped: bool, input_svg: Path) -> str:
 
     # If  many different inputs have the same name disambiguate 1..N
     # by including N in picosvg path
-    input_svg = input_svg.resolve()
+    input_svg = abspath(input_svg)
     nth_of_name = 0
     while (
         picosvg_dest.names_seen.get((nth_of_name, input_svg.name), input_svg)
@@ -307,7 +307,7 @@ def write_picosvg_builds(
     if clipped:
         rule_name = "picosvg_clipped"
     for svg_file in master.sources:
-        svg_file = svg_file.resolve()
+        svg_file = abspath(svg_file)
         dest = picosvg_dest(clipped, svg_file)
         if svg_file in picosvg_builds:
             continue
@@ -368,7 +368,7 @@ def _input_svgs(font_config: FontConfig, master: MasterConfig) -> List[str]:
             picosvg_dest(font_config.clip_to_viewbox, f) for f in master.sources
         ]
     else:
-        svg_files = [str(f.resolve()) for f in master.sources]
+        svg_files = [str(abspath(f)) for f in master.sources]
     return svg_files
 
 

--- a/src/nanoemoji/util.py
+++ b/src/nanoemoji/util.py
@@ -57,14 +57,21 @@ def fs_root() -> Path:
 
 def rel(from_path: Path, to_path: Path) -> Path:
     # relative_to(A,B) doesn't like it if B doesn't start with A
-    abs_from_path = from_path.resolve()
-    abs_to_path = to_path.resolve()
+    abs_from_path = abspath(from_path)
+    abs_to_path = abspath(to_path)
     if abs_from_path.drive != abs_to_path.drive:
         # On Windows, we can't resolve relative paths across drive mount points.
         # We must return the absolute path in this case, or else we get:
         #     ValueError: path is on mount 'D:', start on mount 'C:'
         return abs_to_path
     return Path(os.path.relpath(abs_to_path, abs_from_path))
+
+
+def abspath(path: Path) -> Path:
+    # pathlib.Path.absolute() doesn't do path normalization, whereas Path.resolve()
+    # does normalization but also resolves symlinks which sometimes we don't want to
+    # so here we use good ol' os.path.abspath.
+    return Path(os.path.abspath(path))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
noto-emoji uses symlinks for a couple region flags that are indentical. Currently our use of Path.resolve() to make paths absolute leads to resolving the symlinks and then hard crash because of duplicate glyphs. If we just make the paths absolute without resolving the symbolic links we can support this use case without other changes.

~~I need to add tests before this is mergeable.~~ Added a test