### PR TITLE
Highly sophisticated notdef glyph

### DIFF
--- a/tests/clocks_colr_1.ttx
+++ b/tests/clocks_colr_1.ttx
@@ -15,7 +15,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="3"/>
@@ -49,7 +49,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -30,7 +30,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="3"/>
@@ -79,7 +79,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/clocks_glyf.ttx
+++ b/tests/clocks_glyf.ttx
@@ -15,7 +15,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="3"/>
     <mtx name="e000.0" width="100" lsb="3"/>
@@ -49,7 +49,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/clocks_picosvg.ttx
+++ b/tests/clocks_picosvg.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e001" width="100" lsb="0"/>
@@ -39,7 +39,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/clocks_rects_picosvg.ttx
+++ b/tests/clocks_rects_picosvg.ttx
@@ -12,7 +12,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e001" width="100" lsb="0"/>
@@ -47,7 +47,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/clocks_rects_untouchedsvg.ttx
+++ b/tests/clocks_rects_untouchedsvg.ttx
@@ -12,7 +12,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e001" width="100" lsb="0"/>
@@ -47,7 +47,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/group_opacity_picosvg.ttx
+++ b/tests/group_opacity_picosvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/group_opacity_reuse_picosvg.ttx
+++ b/tests/group_opacity_reuse_picosvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/involutory_matrix_picosvg.ttx
+++ b/tests/involutory_matrix_picosvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/linear_gradient_rect_colr_1.ttx
+++ b/tests/linear_gradient_rect_colr_1.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/omit_empty_color_glyphs.ttx
+++ b/tests/omit_empty_color_glyphs.ttx
@@ -29,7 +29,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="51" yMin="-250" xMax="461" yMax="950">
+      <contour>
+        <pt x="51" y="-250" on="1"/>
+        <pt x="51" y="950" on="1"/>
+        <pt x="461" y="950" on="1"/>
+        <pt x="461" y="-250" on="1"/>
+      </contour>
+      <contour>
+        <pt x="102" y="-199" on="1"/>
+        <pt x="410" y="-199" on="1"/>
+        <pt x="410" y="899" on="1"/>
+        <pt x="102" y="899" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/one_rect_glyf.ttx
+++ b/tests/one_rect_glyf.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="20"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/one_rect_transformed.ttx
+++ b/tests/one_rect_transformed.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="120" lsb="5"/>
     <mtx name=".space" width="120" lsb="0"/>
     <mtx name="e000" width="120" lsb="0"/>
     <mtx name="e000.0" width="120" lsb="7"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/outside_viewbox_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_clipped_colr_1.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="g_25fd" width="100" lsb="0"/>
     <mtx name="g_25fd.0" width="100" lsb="20"/>
@@ -39,7 +39,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/outside_viewbox_not_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_not_clipped_colr_1.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="g_25fd" width="100" lsb="0"/>
     <mtx name="g_25fd.0" width="100" lsb="20"/>
@@ -39,7 +39,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/radial_gradient_rect_colr_1.ttx
+++ b/tests/radial_gradient_rect_colr_1.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_cbdt.ttx
+++ b/tests/rect_cbdt.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="110" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="-20" xMax="45" yMax="90">
+      <contour>
+        <pt x="5" y="-20" on="1"/>
+        <pt x="5" y="90" on="1"/>
+        <pt x="45" y="90" on="1"/>
+        <pt x="45" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="-15" on="1"/>
+        <pt x="40" y="-15" on="1"/>
+        <pt x="40" y="85" on="1"/>
+        <pt x="10" y="85" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_colr_0.ttx
+++ b/tests/rect_colr_0.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="20"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -39,7 +39,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_colr_1.ttx
+++ b/tests/rect_colr_1.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_glyf_colr_1_and_picosvg.ttx
+++ b/tests/rect_glyf_colr_1_and_picosvg.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_glyf_colr_1_and_picosvg_and_cbdt.ttx
+++ b/tests/rect_glyf_colr_1_and_picosvg_and_cbdt.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="110" lsb="0"/>
     <mtx name="e000.0" width="110" lsb="22"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="-20" xMax="45" yMax="90">
+      <contour>
+        <pt x="5" y="-20" on="1"/>
+        <pt x="5" y="90" on="1"/>
+        <pt x="45" y="90" on="1"/>
+        <pt x="45" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="-15" on="1"/>
+        <pt x="40" y="-15" on="1"/>
+        <pt x="40" y="85" on="1"/>
+        <pt x="10" y="85" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_picosvg.ttx
+++ b/tests/rect_picosvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_sbix.ttx
+++ b/tests/rect_sbix.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rect_untouchedsvg.ttx
+++ b/tests/rect_untouchedsvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/rects_colr_1.ttx
+++ b/tests/rects_colr_1.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -41,7 +41,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/reuse_shape_varying_fill.ttx
+++ b/tests/reuse_shape_varying_fill.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/reused_rect_glyf.ttx
+++ b/tests/reused_rect_glyf.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="20"/>
     <mtx name="e000.0" width="100" lsb="20"/>
@@ -41,7 +41,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/reused_shape_2_picosvg.ttx
+++ b/tests/reused_shape_2_picosvg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/reused_shape_glyf.ttx
+++ b/tests/reused_shape_glyf.ttx
@@ -11,7 +11,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="3"/>
     <mtx name="e000.0" width="100" lsb="18"/>
@@ -39,7 +39,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/reused_shape_with_gradient.ttx
+++ b/tests/reused_shape_with_gradient.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="39"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/smiley_cheeks_gradient_svg.ttx
+++ b/tests/smiley_cheeks_gradient_svg.ttx
@@ -9,7 +9,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
@@ -35,7 +35,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/transformed_components_overlap.ttx
+++ b/tests/transformed_components_overlap.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="38"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 

--- a/tests/transformed_gradient_reuse.ttx
+++ b/tests/transformed_gradient_reuse.ttx
@@ -10,7 +10,7 @@
   </GlyphOrder>
 
   <hmtx>
-    <mtx name=".notdef" width="0" lsb="0"/>
+    <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
     <mtx name="e000.0" width="100" lsb="8"/>
@@ -37,7 +37,21 @@
     <!-- The xMin, yMin, xMax and yMax values
          will be recalculated by the compiler. -->
 
-    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+    <TTGlyph name=".notdef" xMin="5" yMin="0" xMax="45" yMax="100">
+      <contour>
+        <pt x="5" y="0" on="1"/>
+        <pt x="5" y="100" on="1"/>
+        <pt x="45" y="100" on="1"/>
+        <pt x="45" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="10" y="5" on="1"/>
+        <pt x="40" y="5" on="1"/>
+        <pt x="40" y="95" on="1"/>
+        <pt x="10" y="95" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
     <TTGlyph name=".space"/><!-- contains no outline data -->
 


### PR DESCRIPTION
A font without a glyph data table fails OTS. A font with no glyphs with outlines emits a 1 byte glyf table but will emerge from woff2 with a 0 byte glyf. Provide a definition of notdef to avoid getting into this situation.

Currently I've only done this when we're actually generating glyf but I suspect even when there is no glyf or cff table (say a pure SVG font) we might want to add something to increase the odds things Just Work.