### PR TITLE
Fix hybrid vector+bitmap color font

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -31,6 +31,7 @@ from nanoemoji.paint import (
     PaintRadialGradient,
     PaintSolid,
 )
+from nanoemoji.png import PNG
 from picosvg.geometric_types import Point, Rect
 from picosvg.svg_meta import number_or_percentage
 from picosvg.svg_reuse import normalize, affine_between
@@ -402,7 +403,7 @@ class ColorGlyph(NamedTuple):
     painted_layers: Optional[Tuple[Paint, ...]]  # None for untouched and bitmap formats
     svg: Optional[SVG]  # None for bitmap formats
     user_transform: Affine2D
-    bitmap: Optional[bytes]  # None for vector formats
+    bitmap: Optional[PNG]  # None for vector formats
 
     @staticmethod
     def create(
@@ -413,7 +414,7 @@ class ColorGlyph(NamedTuple):
         ufo_glyph_name: str,
         codepoints: Tuple[int, ...],
         svg: Optional[SVG],
-        bitmap: Optional[bytes] = None,
+        bitmap: Optional[PNG] = None,
     ) -> "ColorGlyph":
         logging.debug(" ColorGlyph for %s (%s)", ", ".join(filenames), codepoints)
         base_glyph = ufo.newGlyph(ufo_glyph_name)

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -395,27 +395,28 @@ def _mutating_traverse(paint, mutator):
 
 class ColorGlyph(NamedTuple):
     ufo: ufoLib2.Font
-    filename: str
+    filenames: Tuple[str]
     ufo_glyph_name: str  # only if config has keep_glyph_names will this match in font binary
     glyph_id: int
     codepoints: Tuple[int, ...]
     painted_layers: Optional[Tuple[Paint, ...]]  # None for untouched and bitmap formats
-    svg: Optional[SVG]  # picosvg except for untouched and bitmap formats
+    svg: Optional[SVG]  # None for bitmap formats
     user_transform: Affine2D
+    bitmap: Optional[bytes]  # None for vector formats
 
     @staticmethod
     def create(
         font_config: FontConfig,
         ufo: ufoLib2.Font,
-        filename: str,
+        filenames: Sequence[str],
         glyph_id: int,
         ufo_glyph_name: str,
         codepoints: Tuple[int, ...],
         svg: Optional[SVG],
+        bitmap: Optional[bytes] = None,
     ) -> "ColorGlyph":
-        logging.debug(" ColorGlyph for %s (%s)", filename, codepoints)
+        logging.debug(" ColorGlyph for %s (%s)", ", ".join(filenames), codepoints)
         base_glyph = ufo.newGlyph(ufo_glyph_name)
-
         # non-square aspect ratio == proportional width; square == monospace
         view_box = None
         if svg:
@@ -435,23 +436,19 @@ class ColorGlyph(NamedTuple):
         if not font_config.transform.is_degenerate():
             if font_config.has_picosvgs:
                 painted_layers = tuple(
-                    _painted_layers(
-                        filename,
-                        font_config,
-                        svg,
-                        base_glyph.width,
-                    )
+                    _painted_layers(filenames[0], font_config, svg, base_glyph.width)
                 )
 
         return ColorGlyph(
             ufo,
-            filename,
+            tuple(filenames),
             ufo_glyph_name,
             glyph_id,
             codepoints,
             painted_layers,
             svg,
             font_config.transform,
+            bitmap,
         )
 
     def _has_viewbox_for_transform(self) -> bool:

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -396,7 +396,8 @@ def _mutating_traverse(paint, mutator):
 
 class ColorGlyph(NamedTuple):
     ufo: ufoLib2.Font
-    filenames: Tuple[str]
+    svg_filename: str  # empty string means no svg or bitmap filenames
+    bitmap_filename: str
     ufo_glyph_name: str  # only if config has keep_glyph_names will this match in font binary
     glyph_id: int
     codepoints: Tuple[int, ...]
@@ -409,14 +410,17 @@ class ColorGlyph(NamedTuple):
     def create(
         font_config: FontConfig,
         ufo: ufoLib2.Font,
-        filenames: Sequence[str],
+        svg_filename: str,
         glyph_id: int,
         ufo_glyph_name: str,
         codepoints: Tuple[int, ...],
         svg: Optional[SVG],
+        bitmap_filename: str = "",
         bitmap: Optional[PNG] = None,
     ) -> "ColorGlyph":
-        logging.debug(" ColorGlyph for %s (%s)", ", ".join(filenames), codepoints)
+        logging.debug(
+            " ColorGlyph for %s (%s)", svg_filename or bitmap_filename, codepoints
+        )
         base_glyph = ufo.newGlyph(ufo_glyph_name)
         # non-square aspect ratio == proportional width; square == monospace
         view_box = None
@@ -437,12 +441,13 @@ class ColorGlyph(NamedTuple):
         if not font_config.transform.is_degenerate():
             if font_config.has_picosvgs:
                 painted_layers = tuple(
-                    _painted_layers(filenames[0], font_config, svg, base_glyph.width)
+                    _painted_layers(svg_filename, font_config, svg, base_glyph.width)
                 )
 
         return ColorGlyph(
             ufo,
-            tuple(filenames),
+            svg_filename,
+            bitmap_filename,
             ufo_glyph_name,
             glyph_id,
             codepoints,

--- a/src/nanoemoji/glyphmap.py
+++ b/src/nanoemoji/glyphmap.py
@@ -13,18 +13,26 @@
 # limitations under the License.
 
 import csv
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Optional, Tuple
 
 
-class GlyphMapping(NamedTuple):
-    source_stem: str  # source filename w/o suffix, i.e. Path(source_file).stem
+@dataclass(frozen=True)
+class GlyphMapping:
+    # One of the two paths can be set to None, but at least one is required
+    svg_file: Optional[Path]
+    bitmap_file: Optional[Path]
     codepoints: Tuple[int, ...]
     glyph_name: str
 
+    def __post_init__(self):
+        if not any((self.svg_file, self.bitmap_file)):
+            raise ValueError("At least one of svg or bitmap filename is required")
+
     def csv_line(self) -> str:
-        row = [self.source_stem, self.glyph_name]
+        row = [self.svg_file or "", self.bitmap_file or "", self.glyph_name]
         if self.codepoints:
             row.extend(f"{c:04x}" for c in self.codepoints)
         else:
@@ -41,15 +49,18 @@ def load_from(file) -> Tuple[GlyphMapping]:
     reader = csv.reader(file, skipinitialspace=True)
     for row in reader:
         try:
-            source_stem, glyph_name, *cps = row
+            svg_filename, bitmap_filename, glyph_name, *cps = row
         except ValueError as e:
             raise ValueError(f"Error parsing {row} from {file}") from e
+
+        svg_file = None if not svg_filename else Path(svg_filename)
+        bitmap_file = None if not bitmap_filename else Path(bitmap_filename)
 
         if cps and cps != [""]:
             cps = tuple(int(cp, 16) for cp in cps)
         else:
             cps = ()
-        results.append(GlyphMapping(source_stem, cps, glyph_name))
+        results.append(GlyphMapping(svg_file, bitmap_file, cps, glyph_name))
 
     return tuple(results)
 

--- a/src/nanoemoji/glyphmap.py
+++ b/src/nanoemoji/glyphmap.py
@@ -19,12 +19,12 @@ from typing import NamedTuple, Tuple
 
 
 class GlyphMapping(NamedTuple):
-    input_file: Path
+    source_stem: str  # source filename w/o suffix, i.e. Path(source_file).stem
     codepoints: Tuple[int, ...]
     glyph_name: str
 
     def csv_line(self) -> str:
-        row = [self.input_file, self.glyph_name]
+        row = [self.source_stem, self.glyph_name]
         if self.codepoints:
             row.extend(f"{c:04x}" for c in self.codepoints)
         else:
@@ -41,17 +41,15 @@ def load_from(file) -> Tuple[GlyphMapping]:
     reader = csv.reader(file, skipinitialspace=True)
     for row in reader:
         try:
-            input_file, glyph_name, *cps = row
+            source_stem, glyph_name, *cps = row
         except ValueError as e:
             raise ValueError(f"Error parsing {row} from {file}") from e
-
-        input_file = Path(input_file)
 
         if cps and cps != [""]:
             cps = tuple(int(cp, 16) for cp in cps)
         else:
             cps = ()
-        results.append(GlyphMapping(input_file, cps, glyph_name))
+        results.append(GlyphMapping(source_stem, cps, glyph_name))
 
     return tuple(results)
 

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -153,18 +153,12 @@ def _ufo_config(font_config: FontConfig, master: MasterConfig) -> Path:
     return _per_config_file(font_config, "." + master.output_ufo + ".toml")
 
 
-def _glyphmap_rule(font_config: FontConfig, master: MasterConfig) -> str:
-    master_part = ""
-    if font_config.is_vf:
-        master_part = "_" + master.style_name.lower()
-    return "write_" + Path(font_config.output_file).stem + master_part + "_glyphmap"
+def _glyphmap_rule(font_config: FontConfig) -> str:
+    return "write_" + Path(font_config.output_file).stem + "_glyphmap"
 
 
-def _glyphmap_file(font_config: FontConfig, master: MasterConfig) -> Path:
-    master_part = ""
-    if font_config.is_vf:
-        master_part = "." + master.output_ufo
-    return _per_config_file(font_config, master_part + ".glyphmap")
+def _glyphmap_file(font_config: FontConfig) -> Path:
+    return _per_config_file(font_config, ".glyphmap")
 
 
 def module_rule(
@@ -203,7 +197,7 @@ def write_font_rule(nw, font_config: FontConfig, master: MasterConfig):
             (
                 f"--config_file {rel_build(config_file)}",
                 f"--fea_file {rel_build(_fea_file(font_config))}",
-                f"--glyphmap_file {rel_build(_glyphmap_file(font_config, master))}",
+                f"--glyphmap_file {rel_build(_glyphmap_file(font_config))}",
                 "@$out.rsp",
             )
         ),
@@ -214,14 +208,12 @@ def write_font_rule(nw, font_config: FontConfig, master: MasterConfig):
     nw.newline()
 
 
-def write_glyphmap_rule(nw, font_config: FontConfig, master: MasterConfig):
+def write_glyphmap_rule(nw, font_config: FontConfig):
     module_rule(
         nw,
         font_config.glyphmap_generator,
-        f"--output_file $out @$out.rsp",
-        rspfile="$out.rsp",
-        rspfile_content="$in",
-        rule_name=_glyphmap_rule(font_config, master),
+        f"--output_file $out $in",
+        rule_name=_glyphmap_rule(font_config),
         allow_external=True,
     )
     nw.newline()
@@ -434,7 +426,7 @@ def write_fea_build(nw: NinjaWriter, font_config: FontConfig):
     nw.build(
         rel_build(_fea_file(font_config)),
         "write_fea",
-        rel_build(_glyphmap_file(font_config, font_config.default())),
+        rel_build(_glyphmap_file(font_config)),
     )
     nw.newline()
 
@@ -507,22 +499,16 @@ def _update_sources(font_config: FontConfig) -> FontConfig:
     )
 
 
-def write_glyphmap_build(
-    nw: NinjaWriter,
-    font_config: FontConfig,
-    master: MasterConfig,
-):
+def write_glyphmap_build(nw: NinjaWriter, font_config: FontConfig):
     nw.build(
-        rel_build(_glyphmap_file(font_config, master)),
-        _glyphmap_rule(font_config, master),
-        [rel_build(f) for f in master.sources],
+        rel_build(_glyphmap_file(font_config)),
+        _glyphmap_rule(font_config),
+        _source_name_file(font_config),
     )
     nw.newline()
 
 
-def _implicit_inputs_to_font_build(
-    font_config: FontConfig, master: MasterConfig
-) -> List[Path]:
+def _implicit_inputs_to_font_build(font_config: FontConfig) -> List[Path]:
     # these inputs are not passed in as positional argv to write_font; unlike explicit
     # inputs (i.e., .svg or .png files), these are generated files pulled in via CLI
     # flags and hardcoded in the write_font ninja rule; thus we add them only as
@@ -530,7 +516,7 @@ def _implicit_inputs_to_font_build(
     return [
         rel_build(_config_file(font_config)),
         rel_build(_fea_file(font_config)),
-        rel_build(_glyphmap_file(font_config, master)),
+        rel_build(_glyphmap_file(font_config)),
     ]
 
 
@@ -542,7 +528,7 @@ def write_ufo_build(nw: NinjaWriter, font_config: FontConfig, master: MasterConf
         master.output_ufo,
         _ufo_rule(font_config, master),
         _input_files(font_config, master),
-        _implicit_inputs_to_font_build(font_config, master),
+        _implicit_inputs_to_font_build(font_config),
     )
     nw.newline()
 
@@ -554,7 +540,7 @@ def write_static_font_build(nw: NinjaWriter, font_config: FontConfig):
         font_config.output_file,
         _font_rule(font_config),
         _input_files(font_config, master),
-        _implicit_inputs_to_font_build(font_config, master),
+        _implicit_inputs_to_font_build(font_config),
     )
     nw.newline()
 
@@ -622,8 +608,7 @@ def _run(argv):
             # Separate loops for separate content to keep related rules together
 
             for font_config in font_configs:
-                for master in font_config.masters:
-                    write_glyphmap_rule(nw, font_config, master)
+                write_glyphmap_rule(nw, font_config)
 
             for font_config in font_configs:
                 write_config_preamble(nw, font_config)
@@ -632,8 +617,7 @@ def _run(argv):
                 write_fea_build(nw, font_config)
 
             for font_config in font_configs:
-                for master in font_config.masters:
-                    write_glyphmap_build(nw, font_config, master)
+                write_glyphmap_build(nw, font_config)
 
             picosvg_builds = set()
             for font_config in font_configs:

--- a/src/nanoemoji/png.py
+++ b/src/nanoemoji/png.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class PNG(bytes):
+
+    # The first eight bytes of a PNG file always contain the following (decimal) values:
+    #   137 80 78 71 13 10 26 10
+    # https://www.w3.org/TR/PNG-Structure.html
+    SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+    def __new__(cls, *args, **kwargs):
+        self = super().__new__(cls, *args, **kwargs)
+        header = self[:8]
+        if header != cls.SIGNATURE:
+            raise ValueError("Invalid PNG file: bad signature {header!r}")
+        return self

--- a/src/nanoemoji/png.py
+++ b/src/nanoemoji/png.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from pathlib import Path
+from typing import Union
+
 
 class PNG(bytes):
 
@@ -26,3 +30,7 @@ class PNG(bytes):
         if header != cls.SIGNATURE:
             raise ValueError("Invalid PNG file: bad signature {header!r}")
         return self
+
+    @classmethod
+    def read_from(cls, path: Union[str, os.PathLike]) -> "PNG":
+        return cls(Path(path).read_bytes())

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -434,7 +434,7 @@ def _add_glyph(svg: SVG, color_glyph: ColorGlyph, reuse_cache: ReuseCache):
 
     view_box = color_glyph.svg.view_box()
     if view_box is None:
-        raise ValueError(f"{color_glyph.filenames[0]} must declare view box")
+        raise ValueError(f"{color_glyph.svg_filename} must declare view box")
 
     # https://github.com/googlefonts/nanoemoji/issues/58: group needs transform
     svg_g.attrib["transform"] = _svg_matrix(color_glyph.transform_for_otsvg_space())

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -434,7 +434,7 @@ def _add_glyph(svg: SVG, color_glyph: ColorGlyph, reuse_cache: ReuseCache):
 
     view_box = color_glyph.svg.view_box()
     if view_box is None:
-        raise ValueError(f"{color_glyph.filename} must declare view box")
+        raise ValueError(f"{color_glyph.filenames[0]} must declare view box")
 
     # https://github.com/googlefonts/nanoemoji/issues/58: group needs transform
     svg_g.attrib["transform"] = _svg_matrix(color_glyph.transform_for_otsvg_space())

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -51,6 +51,7 @@ from nanoemoji.paint import (
     PaintGlyph,
     PaintSolid,
 )
+from nanoemoji.png import PNG
 from nanoemoji.svg import make_svg_table
 from nanoemoji.svg_path import draw_svg_path
 from nanoemoji import util
@@ -92,7 +93,7 @@ class InputGlyph(NamedTuple):
     codepoints: Tuple[int, ...]
     glyph_name: str
     svg: Optional[SVG]  # None for bitmap formats
-    bitmap: Optional[bytes]  # None for vector formats
+    bitmap: Optional[PNG]  # None for vector formats
 
 
 # A color font generator.
@@ -784,7 +785,7 @@ def _inputs(
         if font_config.has_bitmaps:
             if png_file is None:
                 raise ValueError(f"No {file_stem}.png among inputs")
-            bitmap = png_file.read_bytes()
+            bitmap = PNG(png_file.read_bytes())
 
         filenames = []
         if svg_file is not None:

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -769,7 +769,7 @@ def _inputs(
         files_by_stem.setdefault(input_file.stem, [None, None])[i] = input_file
 
     # match inputs with respective glyph mappings by their file stem
-    glyph_mappings_by_stem = {g.input_file.stem: g for g in glyph_mappings}
+    glyph_mappings_by_stem = {g.source_stem: g for g in glyph_mappings}
     for file_stem, (svg_file, png_file) in files_by_stem.items():
         g = glyph_mappings_by_stem[file_stem]
         svg = None

--- a/src/nanoemoji/write_glyphmap.py
+++ b/src/nanoemoji/write_glyphmap.py
@@ -15,17 +15,23 @@
 """Default glyphmap writer. Writes rows like:
 
 
-emoji_u270d_1f3fb, g_270d_1f3fb, "270d,1f3fb"
+picosvg/clipped/emoji_u270d_1f3fb.svg, bitmap/emoji_u270d_1f3fb.png, g_270d_1f3fb, 270d, 1f3fb
 
+The first two columns represent respectively the SVG and bitmap filenames; either can be
+left empty if the font is vector- or bitmap-only.
+The third column is the UFO/PostScript glyph name, and it's required.
+The fourth and the remaining columns are optional, and contain the Unicode codepoints
+as hexadecimal digits; a single codepoint gets added to the cmap, more than one produce
+a GSUB ligature, no codepoint leaves the glyph unmapped.
 """
 
 
+import enum
 from absl import app
 from absl import flags
 from nanoemoji.glyph import glyph_name
 from nanoemoji.glyphmap import GlyphMapping
 from nanoemoji import codepoints
-from nanoemoji import features
 from nanoemoji import util
 from pathlib import Path
 from typing import Iterator, Sequence, Tuple
@@ -35,20 +41,28 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
-def _glyphmappings(source_names: Sequence[str]) -> Iterator[GlyphMapping]:
-    yield from (
-        GlyphMapping(source_stem, cps, glyph_name(cps))
-        for source_stem, cps in zip(
-            (Path(name).stem for name in source_names),
-            (codepoints.from_filename(name) for name in source_names),
-        )
-    )
+class InputFileSuffix(enum.Enum):
+    SVG = ".svg"
+    PNG = ".png"
+
+
+def _glyphmappings(input_files: Sequence[str]) -> Iterator[GlyphMapping]:
+    # group .svg and/or .png files with the same filename stem
+    sources_by_stem = {}
+    suffix_index = {InputFileSuffix.SVG: 0, InputFileSuffix.PNG: 1}
+    for filename in input_files:
+        input_file = Path(filename)
+        i = suffix_index[InputFileSuffix(input_file.suffix)]
+        sources_by_stem.setdefault(input_file.stem, [None, None])[i] = input_file
+    for source_stem, files in sources_by_stem.items():
+        cps = tuple(codepoints.from_filename(source_stem))
+        yield GlyphMapping(*files, cps, glyph_name(cps))
 
 
 def main(argv):
-    source_names = Path(argv[1]).read_text().splitlines()
+    input_files = util.expand_ninja_response_files(argv[1:])
     with util.file_printer(FLAGS.output_file) as print:
-        for gm in _glyphmappings(source_names):
+        for gm in _glyphmappings(input_files):
             # filename(s), glyph_name, codepoint(s)
             print(gm.csv_line())
 

--- a/src/nanoemoji/write_glyphmap.py
+++ b/src/nanoemoji/write_glyphmap.py
@@ -15,7 +15,7 @@
 """Default glyphmap writer. Writes rows like:
 
 
-picosvg/regular/clipped/emoji_u270d_1f3fb.svg, "270d,1f3fb", g_270d_1f3fb
+../noto-emoji/svg/emoji_u270d_1f3fb.svg, g_270d_1f3fb, "270d,1f3fb"
 
 """
 
@@ -28,15 +28,15 @@ from nanoemoji import codepoints
 from nanoemoji import features
 from nanoemoji import util
 from pathlib import Path
-from typing import Sequence, Tuple
+from typing import Iterator, Sequence, Tuple
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
-def _glyphmappings(input_files: Sequence[str]) -> Tuple[GlyphMapping]:
-    return tuple(
+def _glyphmappings(input_files: Sequence[str]) -> Iterator[GlyphMapping]:
+    yield from (
         GlyphMapping(Path(input_file), cps, glyph_name(cps))
         for input_file, cps in zip(
             input_files,
@@ -49,7 +49,7 @@ def main(argv):
     input_files = util.expand_ninja_response_files(argv[1:])
     with util.file_printer(FLAGS.output_file) as print:
         for gm in _glyphmappings(input_files):
-            # filename, codepoint(s), glyph name
+            # filename(s), glyph_name, codepoint(s)
             print(gm.csv_line())
 
 

--- a/src/nanoemoji/write_glyphmap.py
+++ b/src/nanoemoji/write_glyphmap.py
@@ -15,7 +15,7 @@
 """Default glyphmap writer. Writes rows like:
 
 
-../noto-emoji/svg/emoji_u270d_1f3fb.svg, g_270d_1f3fb, "270d,1f3fb"
+emoji_u270d_1f3fb, g_270d_1f3fb, "270d,1f3fb"
 
 """
 
@@ -35,20 +35,20 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string("output_file", "-", "Output filename ('-' means stdout)")
 
 
-def _glyphmappings(input_files: Sequence[str]) -> Iterator[GlyphMapping]:
+def _glyphmappings(source_names: Sequence[str]) -> Iterator[GlyphMapping]:
     yield from (
-        GlyphMapping(Path(input_file), cps, glyph_name(cps))
-        for input_file, cps in zip(
-            input_files,
-            tuple(codepoints.from_filename(Path(f).name) for f in input_files),
+        GlyphMapping(source_stem, cps, glyph_name(cps))
+        for source_stem, cps in zip(
+            (Path(name).stem for name in source_names),
+            (codepoints.from_filename(name) for name in source_names),
         )
     )
 
 
 def main(argv):
-    input_files = util.expand_ninja_response_files(argv[1:])
+    source_names = Path(argv[1]).read_text().splitlines()
     with util.file_printer(FLAGS.output_file) as print:
-        for gm in _glyphmappings(input_files):
+        for gm in _glyphmappings(source_names):
             # filename(s), glyph_name, codepoint(s)
             print(gm.csv_line())
 

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -123,7 +123,13 @@ def test_transform_and_width(
     ).validate()
     ufo = _ufo(config)
     color_glyph = ColorGlyph.create(
-        config, ufo, "duck", 1, "glyph_name", [0x0042], SVG.fromstring(svg_str)
+        config,
+        ufo,
+        ("duck",),
+        1,
+        "glyph_name",
+        [0x0042],
+        SVG.fromstring(svg_str),
     )
 
     assert color_glyph.transform_for_font_space() == pytest.approx(expected_transform)
@@ -467,7 +473,7 @@ def _round_coords(paint, prec=5):
 def test_color_glyph_layers(svg_in, expected_paints):
     config = FontConfig(upem=1000, ascender=1000, descender=0, width=1000)
     color_glyph = ColorGlyph.create(
-        config, _ufo(config), "duck", 1, "g_name", [0x0042], _nsvg(svg_in)
+        config, _ufo(config), ("duck",), 1, "g_name", [0x0042], _nsvg(svg_in)
     ).mutating_traverse(_round_coords)
 
     actual_paints = color_glyph.painted_layers

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -123,13 +123,7 @@ def test_transform_and_width(
     ).validate()
     ufo = _ufo(config)
     color_glyph = ColorGlyph.create(
-        config,
-        ufo,
-        ("duck",),
-        1,
-        "glyph_name",
-        [0x0042],
-        SVG.fromstring(svg_str),
+        config, ufo, "duck", 1, "glyph_name", [0x0042], SVG.fromstring(svg_str)
     )
 
     assert color_glyph.transform_for_font_space() == pytest.approx(expected_transform)
@@ -473,7 +467,7 @@ def _round_coords(paint, prec=5):
 def test_color_glyph_layers(svg_in, expected_paints):
     config = FontConfig(upem=1000, ascender=1000, descender=0, width=1000)
     color_glyph = ColorGlyph.create(
-        config, _ufo(config), ("duck",), 1, "g_name", [0x0042], _nsvg(svg_in)
+        config, _ufo(config), "duck", 1, "g_name", [0x0042], _nsvg(svg_in)
     ).mutating_traverse(_round_coords)
 
     actual_paints = color_glyph.painted_layers

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -16,6 +16,7 @@ from nanoemoji import config
 from pathlib import Path
 import pytest
 from test_helper import test_data_dir, locate_test_file
+import shutil
 import tempfile
 from typing import Iterable
 
@@ -32,15 +33,17 @@ def test_read_write_config(config_file):
     tmp_dir = Path(tempfile.mkdtemp())
     if config_file:
         config_file = locate_test_file(config_file)
-        tmp_dir = tmp_dir / config_file.name
+        tmp_config = tmp_dir / config_file.name
     else:
-        tmp_dir = tmp_dir / "the_default.toml"
+        tmp_config = tmp_dir / "the_default.toml"
 
     original = config.load(config_file)
-    config.write(tmp_dir, original)
-    reloaded = config.load(tmp_dir)
+    config.write(tmp_config, original)
+    reloaded = config.load(tmp_config)
 
     assert original == reloaded
+
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/glyphmap_test.py
+++ b/tests/glyphmap_test.py
@@ -24,6 +24,8 @@ import io
         GlyphMapping(Path("duck/file.svg"), (), "q"),
         GlyphMapping(Path("file.svg"), (0x32,), "q2"),
         GlyphMapping(Path("duck/file.svg"), (0x123, 0x234), "g_123_234"),
+        # this name contains a comma, we check that csv.writer correctly escapes it
+        GlyphMapping(Path("foo/bar,baz.svg"), (0x0041,), "g_41"),
     ),
 )
 def test_glyphmap_round_trip(glyph_mapping):

--- a/tests/glyphmap_test.py
+++ b/tests/glyphmap_test.py
@@ -21,11 +21,11 @@ import io
 @pytest.mark.parametrize(
     "glyph_mapping",
     (
-        GlyphMapping("foo", (), "q"),
-        GlyphMapping("bar", (0x32,), "q2"),
-        GlyphMapping("baz", (0x123, 0x234), "g_123_234"),
+        GlyphMapping(Path("duck/file.svg"), None, (), "q"),
+        GlyphMapping(Path("file.svg"), None, (0x32,), "q2"),
+        GlyphMapping(Path("duck/file.svg"), None, (0x123, 0x234), "g_123_234"),
         # this name contains a comma, we check that csv.writer correctly escapes it
-        GlyphMapping("foo,bar,baz", (0x0041,), "g_41"),
+        GlyphMapping(Path("foo/bar,baz.svg"), None, (0x0041,), "g_41"),
     ),
 )
 def test_glyphmap_round_trip(glyph_mapping):

--- a/tests/glyphmap_test.py
+++ b/tests/glyphmap_test.py
@@ -21,11 +21,11 @@ import io
 @pytest.mark.parametrize(
     "glyph_mapping",
     (
-        GlyphMapping(Path("duck/file.svg"), (), "q"),
-        GlyphMapping(Path("file.svg"), (0x32,), "q2"),
-        GlyphMapping(Path("duck/file.svg"), (0x123, 0x234), "g_123_234"),
+        GlyphMapping("foo", (), "q"),
+        GlyphMapping("bar", (0x32,), "q2"),
+        GlyphMapping("baz", (0x123, 0x234), "g_123_234"),
         # this name contains a comma, we check that csv.writer correctly escapes it
-        GlyphMapping(Path("foo/bar,baz.svg"), (0x0041,), "g_41"),
+        GlyphMapping("foo,bar,baz", (0x0041,), "g_41"),
     ),
 )
 def test_glyphmap_round_trip(glyph_mapping):

--- a/tests/minimal_static/config_cbdt.toml
+++ b/tests/minimal_static/config_cbdt.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "cbdt"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/minimal_static/config_glyf_colr_1_and_picosvg.toml
+++ b/tests/minimal_static/config_glyf_colr_1_and_picosvg.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "glyf_colr_1_and_picosvg"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/minimal_static/config_glyf_colr_1_and_picosvg_and_cbdt.toml
+++ b/tests/minimal_static/config_glyf_colr_1_and_picosvg_and_cbdt.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "glyf_colr_1_and_picosvg_and_cbdt"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/minimal_static/config_sbix.toml
+++ b/tests/minimal_static/config_sbix.toml
@@ -1,0 +1,13 @@
+output_file = "Font.ttf"
+color_format = "sbix"
+
+[axis.wght]
+name = "Weight"
+default = 400
+
+[master.regular]
+style_name = "Regular"
+srcs = ["svg/*.svg"]
+
+[master.regular.position]
+wght = 400

--- a/tests/nanoemoji_test.py
+++ b/tests/nanoemoji_test.py
@@ -104,7 +104,7 @@ def test_build_static_font_default_config_cli_svg_list():
 def _build_and_check_ttx(config_overrides, svgs, expected_ttx):
     config_file = _mkdtemp() / "config.toml"
     font_config, _ = color_font_config(
-        config_overrides, svgs, tmp_dir=str(config_file.parent)
+        config_overrides, svgs, tmp_dir=config_file.parent
     )
     config.write(config_file, font_config)
     print(config_file, font_config)

--- a/tests/png_test.py
+++ b/tests/png_test.py
@@ -1,0 +1,22 @@
+from nanoemoji.png import PNG
+import pytest
+
+
+def test_good_png_signature():
+    # example from https://en.wikipedia.org/wiki/Portable_Network_Graphics
+    data = bytes(
+        int(b, 16)
+        for b in (
+            "89 50 4E 47 0D 0A 1A 0A 00 00 00 0D 49 48 44 52 "
+            "00 00 00 01 00 00 00 01 08 02 00 00 00 90 77 53 "
+            "DE 00 00 00 0C 49 44 41 54 08 D7 63 F8 CF C0 00 "
+            "00 03 01 01 00 18 DD 8D B0 00 00 00 00 49 45 4E "
+            "44 AE 42 60 82"
+        ).split()
+    )
+    assert PNG(data) == data
+
+
+def test_bad_png_signature():
+    with pytest.raises(ValueError, match="bad signature"):
+        PNG(b"<?xml")

--- a/tests/rect_cbdt.ttx
+++ b/tests/rect_cbdt.ttx
@@ -11,7 +11,7 @@
   <hmtx>
     <mtx name=".notdef" width="0" lsb="0"/>
     <mtx name=".space" width="100" lsb="0"/>
-    <mtx name="e000" width="110" lsb="0"/>
+    <mtx name="e000" width="100" lsb="0"/>
   </hmtx>
 
   <cmap>
@@ -51,7 +51,7 @@
           <height value="128"/>
           <width value="128"/>
           <BearingX value="0"/>
-          <BearingY value="100"/>
+          <BearingY value="104"/>
           <Advance value="116"/>
         </SmallGlyphMetrics>
         <extfileimagedata value="e000.png"/>
@@ -64,8 +64,8 @@
     <strike index="0">
       <bitmapSizeTable>
         <sbitLineMetrics direction="hori">
-          <ascender value="94"/>
-          <descender value="-22"/>
+          <ascender value="104"/>
+          <descender value="-24"/>
           <widthMax value="116"/>
           <caretSlopeNumerator value="0"/>
           <caretSlopeDenominator value="0"/>
@@ -78,8 +78,8 @@
           <pad2 value="0"/>
         </sbitLineMetrics>
         <sbitLineMetrics direction="vert">
-          <ascender value="94"/>
-          <descender value="-22"/>
+          <ascender value="104"/>
+          <descender value="-24"/>
           <widthMax value="116"/>
           <caretSlopeNumerator value="0"/>
           <caretSlopeDenominator value="0"/>
@@ -94,8 +94,8 @@
         <colorRef value="0"/>
         <startGlyphIndex value="2"/>
         <endGlyphIndex value="2"/>
-        <ppemX value="105"/>
-        <ppemY value="105"/>
+        <ppemX value="116"/>
+        <ppemY value="116"/>
         <bitDepth value="32"/>
         <flags value="1"/>
       </bitmapSizeTable>

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -48,31 +48,29 @@ def parse_svg(filename, locate=False, topicosvg=True):
     return svg.topicosvg(inplace=True) if topicosvg else svg
 
 
-def rasterize_svg(filename, bitmap_resolution):
+def rasterize_svg(input_file: Path, output_file: Path, resolution: int = 128) -> PNG:
     resvg = shutil.which("resvg")
     if not resvg:
         pytest.skip("resvg not installed")
-    with tempfile.TemporaryDirectory(prefix="nanoemoji-resvg-") as tmpdir:
-        output_file = Path(tmpdir) / Path(filename).with_suffix(".png").name
-        result = subprocess.run(
-            [
-                resvg,
-                "-h",
-                f"{bitmap_resolution}",
-                "-w",
-                f"{bitmap_resolution}",
-                filename,
-                output_file,
-            ]
-        )
-        return PNG(output_file.read_bytes())
+    result = subprocess.run(
+        [
+            resvg,
+            "-h",
+            f"{resolution}",
+            "-w",
+            f"{resolution}",
+            input_file,
+            output_file,
+        ]
+    )
+    return PNG.read_from(output_file)
 
 
 def color_font_config(config_overrides, svgs, tmp_dir=None):
     if tmp_dir is None:
-        tmp_dir = tempfile.gettempdir()
+        tmp_dir = Path(tempfile.gettempdir())
     svgs = tuple(locate_test_file(s) for s in svgs)
-    fea_file = os.path.join(tmp_dir, "test.fea")
+    fea_file = tmp_dir / "test.fea"
     rgi_seqs = tuple(codepoints.from_filename(str(f)) for f in svgs)
     with open(fea_file, "w") as f:
         f.write(features.generate_fea(rgi_seqs))
@@ -86,28 +84,48 @@ def color_font_config(config_overrides, svgs, tmp_dir=None):
             descender=0,
             width=100,
             keep_glyph_names=True,
-            fea_file=fea_file,
+            fea_file=str(fea_file),
         )
         ._replace(**config_overrides)
     )
 
-    topicosvg = True if font_config.has_picosvgs else False
+    has_svgs = font_config.has_svgs
+    has_picosvgs = font_config.has_picosvgs
+    has_bitmaps = font_config.has_bitmaps
+
+    svg_inputs = [(None, None)] * len(svgs)
+    if has_svgs:
+        svg_inputs = [
+            (Path(os.path.relpath(svg)), parse_svg(svg, topicosvg=has_picosvgs))
+            for svg in svgs
+        ]
+
+    bitmap_inputs = [(None, None)] * len(svgs)
+    if has_bitmaps:
+        bitmap_inputs = [
+            (
+                tmp_dir / (svg.stem + ".png"),
+                rasterize_svg(
+                    svg, tmp_dir / (svg.stem + ".png"), font_config.bitmap_resolution
+                ),
+            )
+            for svg in svgs
+        ]
 
     return (
         font_config,
         [
             write_font.InputGlyph(
-                (os.path.relpath(svg),),
+                svg_file,
+                bitmap_file,
                 (0xE000 + idx,),
                 glyph_name((0xE000 + idx,)),
-                parse_svg(svg, topicosvg=topicosvg),
-                bitmap=(
-                    rasterize_svg(svg, font_config.bitmap_resolution)
-                    if font_config.has_bitmaps
-                    else None
-                ),
+                svg,
+                bitmap,
             )
-            for idx, svg in enumerate(svgs)
+            for idx, ((svg_file, svg), (bitmap_file, bitmap)) in enumerate(
+                zip(svg_inputs, bitmap_inputs)
+            )
         ],
     )
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -26,6 +26,7 @@ from nanoemoji import config
 from nanoemoji import features
 from nanoemoji.glyph import glyph_name
 from nanoemoji import write_font
+from nanoemoji.png import PNG
 from pathlib import Path
 from picosvg.svg import SVG
 import pytest
@@ -64,7 +65,7 @@ def rasterize_svg(filename, bitmap_resolution):
                 output_file,
             ]
         )
-        return output_file.read_bytes()
+        return PNG(output_file.read_bytes())
 
 
 def color_font_config(config_overrides, svgs, tmp_dir=None):

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -528,27 +528,26 @@ def test_inputs_have_svg_and_or_bitmap(tmp_path, color_format, expected_input_fo
     glyph_mappings = []
     argv = []
     for i, svg_file in enumerate(("rect.svg", "rect2.svg")):
-        svg_file = test_helper.locate_test_file(svg_file)
-        svg_file2 = Path(shutil.copy(svg_file, tmp_path))
+        svg_file = Path(shutil.copy(test_helper.locate_test_file(svg_file), tmp_path))
 
         if expected_input_format & InputFormat.SVG:
-            argv.append(str(svg_file2))
+            argv.append(str(svg_file))
 
         if expected_input_format & InputFormat.PNG:
-            png_file = svg_file2.with_suffix(".png")
+            png_file = svg_file.with_suffix(".png")
             png_file.write_bytes(
-                test_helper.rasterize_svg(svg_file2, config.bitmap_resolution)
+                test_helper.rasterize_svg(svg_file, config.bitmap_resolution)
             )
             argv.append(str(png_file))
 
-        glyph_mappings.append(GlyphMapping(svg_file, (cp + i,), f"uni{i:04X}"))
+        glyph_mappings.append(GlyphMapping(svg_file.stem, (cp + i,), f"uni{i:04X}"))
 
     inputs = list(write_font._inputs(config, glyph_mappings, argv))
 
     for ginp, gmap in zip(inputs, glyph_mappings):
         file_stems = {Path(f).stem for f in ginp.filenames}
         assert len(file_stems) == 1
-        assert next(iter(file_stems)) == gmap.input_file.stem
+        assert next(iter(file_stems)) == gmap.source_stem
         assert len(ginp.filenames) == (
             2 if expected_input_format == InputFormat.SVG | InputFormat.PNG else 1
         )

--- a/tests/write_test_glyphmap.py
+++ b/tests/write_test_glyphmap.py
@@ -46,7 +46,7 @@ def main(argv):
     svg_files = util.expand_ninja_response_files(argv[1:])
     with util.file_printer(FLAGS.output_file) as print:
         for gm in _glyphmappings(svg_files):
-            # filename, codepoint(s), glyph name
+            # filename, glyph_name, codepoint(s)
             print(gm.csv_line())
 
 


### PR DESCRIPTION
Fixes #382 

Before this PR, the assumption in many parts of the codebase was that there were either vector-only or bitmap-only color formats; and for the former, the `ColorGlyph.filename` pointed to an `.svg` file, whereas for the latter, it pointed to a `.png` file. Then #370 introduced the notion of hybrid `glyf_colr_1_and_picosvg_and_cbdt` font that contains CBDT, SVG and COLR tables. However, the CBDT table was still reading the PNG bytes from the same `ColorGlyph.filename`, but the latter still pointed to an `.svg` file, hence it was invalid.

After this PR, `ColorGlyph` object gets an additional optional `bitmap` attribute containing the PNG bytes, in addition to the existing optional `svg` attribute containing a `picosvg.SVG` object. Both are optional, though at least one is required; for hybird vector+bitmap formats, both are not None.

~~The `ColorGlyph.bitmap` bytes are read in `nanoemoji.write_font._inputs` function, from the `.png` file at the same location as the input `ColorGlyph.filename`; i.e. for bitmap-only formats, this _is_ the `ColorGlyph.filename` itself; whereas for hybrid format, this is a file with the same name but different `*.png` suffix in the same directory as the (picosvg) `*.svg`. This effectively becomes an inplicit dependency, and I added them to the ninja write_font build rule so that they are taken into account when building the hybrid font.
Defining a different build subdirectory where to place the png files for the hybrid build, would have required that nanoemoji.write_font be changed to explicitly take the additional input PNG files, or alternatively some flag to translate from the *.svg to the respective *.png. All in all, my current apprach is simpler and keeps the changes to a minimum, so I went with that.~~

EDIT: After Rod's review, I reverted to adding both the svg and png filenames to the glyphmap.csv as first two columns, one of the two can be omitted (left empty). The default `write_glyphmap` script takes all the .svg and .png input files and matches them by their path stem (basename excluding the suffix) and places them on the same row, generating codepoints and glyph_name from their shared stem.
`write_font` parses the glyphmap.csv to obtain the list of svg and/or png input filenames, loads one or both depending on whether the desired config's color format `has_svgs` or `has_bitmaps` or both, and assigns them to a ColorGlyph.
