### PR TITLE
Add support for quantizing PNGs with pngquant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "ufoLib2>=0.6.2",
         "resvg-cli>=0.22.0.post3",
         "zopfli>=0.2.1",
+        "pngquant-cli>=2.17.0.post5",
     ],
     extras_require=extras_require,
     # this is so we can use the built-in dataclasses module

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -113,6 +113,12 @@ flags.DEFINE_integer(
 flags.DEFINE_bool(
     "use_zopflipng", None, "Whether or not to compress PNGs using zopfli."
 )
+flags.DEFINE_bool(
+    "use_pngquant", None, "Whether or not to quantize PNGs using pngquant."
+)
+flags.DEFINE_string(
+    "pngquant_flags", None, "Additional options to pass on to pngquant."
+)
 
 
 class Axis(NamedTuple):
@@ -163,6 +169,10 @@ class FontConfig(NamedTuple):
     glyphmap_generator: str = "nanoemoji.write_glyphmap"
     bitmap_resolution: int = 128
     use_zopflipng: bool = True
+    use_pngquant: bool = True
+    # we default to the same PNGQUANTFLAGS used in noto-emoji's Makefile:
+    # https://github.com/googlefonts/noto-emoji/blob/9a5261d/Makefile#L24
+    pngquant_flags: str = "--speed 1 --skip-if-larger --quality 85-95"
     pretty_print: bool = False
     axes: Tuple[Axis, ...] = ()
     masters: Tuple[MasterConfig, ...] = ()
@@ -262,6 +272,8 @@ def write(dest: Path, config: FontConfig):
         "glyphmap_generator": config.glyphmap_generator,
         "bitmap_resolution": config.bitmap_resolution,
         "use_zopflipng": config.use_zopflipng,
+        "use_pngquant": config.use_pngquant,
+        "pngquant_flags": config.pngquant_flags,
         "axis": {
             a.axisTag: {
                 "name": a.name,
@@ -348,6 +360,8 @@ def load(
     glyphmap_generator = _pop_flag(config, "glyphmap_generator")
     bitmap_resolution = _pop_flag(config, "bitmap_resolution")
     use_zopflipng = _pop_flag(config, "use_zopflipng")
+    use_pngquant = _pop_flag(config, "use_pngquant")
+    pngquant_flags = _pop_flag(config, "pngquant_flags")
 
     axes = []
     for axis_tag, axis_config in config.pop("axis").items():
@@ -428,6 +442,8 @@ def load(
         glyphmap_generator=glyphmap_generator,
         bitmap_resolution=bitmap_resolution,
         use_zopflipng=use_zopflipng,
+        use_pngquant=use_pngquant,
+        pngquant_flags=pngquant_flags,
         axes=tuple(axes),
         masters=tuple(masters),
         source_names=tuple(sorted(source_names)),

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -472,6 +472,8 @@ def _input_files(font_config: FontConfig, master: MasterConfig) -> List[Path]:
             dest_func = zopflipng_dest
         elif font_config.use_pngquant:
             dest_func = pngquant_dest
+        # zopflipng always happens after pngquant, so when both are true
+        # the final desired file is zopflipng_dest
         input_files.extend(dest_func(f) for f in master.sources)
     return input_files
 

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -227,10 +227,10 @@ def write_config_preamble(nw, font_config: FontConfig):
 
         if font_config.use_pngquant:
             # always overwrite using --force
-            pngquant_args = f"-f {font_config.pngquant_flags} -o $out $in"
+            pngquant_args = f"-f {font_config.pngquant_flags}"
             if FLAGS.verbosity:
                 pngquant_args = "-v " + pngquant_args
-            nw.rule("pngquant", f"pngquant {pngquant_args}")
+            module_rule(nw, "pngquant", f"-i $in -o $out -- {pngquant_args}")
             nw.newline()
 
     for master in font_config.masters:

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -52,7 +52,7 @@ import shlex
 import shutil
 import subprocess
 import sys
-from typing import List, NamedTuple, Optional, Tuple, Set, Sequence
+from typing import Callable, List, NamedTuple, Optional, Tuple, Set, Sequence
 
 
 FLAGS = flags.FLAGS
@@ -223,6 +223,15 @@ def write_config_preamble(nw, font_config: FontConfig):
             if FLAGS.verbosity:
                 zopfli_args = "-v " + zopfli_args
             nw.rule("zopflipng", f"{sys.executable} -m zopfli.png {zopfli_args}")
+            nw.newline()
+
+        if font_config.use_pngquant:
+            # always overwrite using --force
+            pngquant_args = f"-f {font_config.pngquant_flags} -o $out $in"
+            if FLAGS.verbosity:
+                pngquant_args = "-v " + pngquant_args
+            nw.rule("pngquant", f"pngquant {pngquant_args}")
+            nw.newline()
 
     for master in font_config.masters:
         write_font_rule(nw, font_config, master)
@@ -280,6 +289,10 @@ def zopflipng_dir() -> Path:
     return build_dir() / "zopflipng"
 
 
+def pngquant_dir() -> Path:
+    return build_dir() / "pngquant"
+
+
 def svg2png_dir() -> Path:
     return build_dir() / "imagediff" / "svg2png"
 
@@ -323,6 +336,10 @@ def bitmap_dest(input_svg: Path) -> Path:
 
 def zopflipng_dest(input_svg: Path) -> Path:
     return _dest_for_src(zopflipng_dest, zopflipng_dir(), input_svg, ".png")
+
+
+def pngquant_dest(input_svg: Path) -> Path:
+    return _dest_for_src(pngquant_dest, pngquant_dir(), input_svg, ".png")
 
 
 def svg2png_dest(input_svg: Path) -> Path:
@@ -374,16 +391,22 @@ def write_bitmap_builds(
         nw.build(dest, "write_bitmap", rel_build(svg_file))
 
 
-def write_zopflipng_builds(
-    zopflipng_builds: Set[Path], nw: NinjaWriter, master: MasterConfig
+def write_compressed_bitmap_builds(
+    builds: Set[Path],
+    nw: NinjaWriter,
+    master: MasterConfig,
+    rule_name: str,
+    dest_dir: Path,
+    infile_fn: Callable[[Path], Path],
+    outfile_fn: Callable[[Path], Path],
 ):
-    os.makedirs(str(zopflipng_dir()), exist_ok=True)
+    os.makedirs(str(dest_dir), exist_ok=True)
     for svg_file in master.sources:
-        dest = zopflipng_dest(svg_file)
-        if dest in zopflipng_builds:
+        dest = outfile_fn(svg_file)
+        if dest in builds:
             continue
-        zopflipng_builds.add(dest)
-        nw.build(dest, "zopflipng", bitmap_dest(svg_file))
+        builds.add(dest)
+        nw.build(dest, rule_name, infile_fn(svg_file))
 
 
 def write_fea_build(nw: NinjaWriter, font_config: FontConfig):
@@ -444,7 +467,11 @@ def _input_files(font_config: FontConfig, master: MasterConfig) -> List[Path]:
     if font_config.has_untouchedsvgs:
         input_files.extend(rel_build(f) for f in master.sources)
     if font_config.has_bitmaps:
-        dest_func = zopflipng_dest if font_config.use_zopflipng else bitmap_dest
+        dest_func = bitmap_dest
+        if font_config.use_zopflipng:
+            dest_func = zopflipng_dest
+        elif font_config.use_pngquant:
+            dest_func = pngquant_dest
         input_files.extend(dest_func(f) for f in master.sources)
     return input_files
 
@@ -599,18 +626,51 @@ def _run(argv):
 
             bitmap_builds = set()
             for font_config in font_configs:
-                for master in font_config.masters:
-                    if font_config.has_bitmaps:
-                        write_bitmap_builds(
-                            bitmap_builds, nw, font_config.clip_to_viewbox, master
-                        )
+                if font_config.has_bitmaps:
+                    assert not font_config.is_vf
+                    write_bitmap_builds(
+                        bitmap_builds,
+                        nw,
+                        font_config.clip_to_viewbox,  # currently unused
+                        font_config.masters[0],
+                    )
             nw.newline()
 
             zopflipng_builds = set()
+            pngquant_builds = set()
             for font_config in font_configs:
-                for master in font_config.masters:
-                    if font_config.has_bitmaps and font_config.use_zopflipng:
-                        write_zopflipng_builds(zopflipng_builds, nw, master)
+                if not font_config.has_bitmaps or not (
+                    font_config.use_zopflipng or font_config.use_pngquant
+                ):
+                    continue
+                assert not font_config.is_vf
+
+                master = font_config.masters[0]
+                if font_config.use_pngquant:
+                    write_compressed_bitmap_builds(
+                        pngquant_builds,
+                        nw,
+                        master,
+                        rule_name="pngquant",
+                        dest_dir=pngquant_dir(),
+                        infile_fn=bitmap_dest,
+                        outfile_fn=pngquant_dest,
+                    )
+
+                if font_config.use_zopflipng:
+                    zopflipng_infile_fn = bitmap_dest
+                    if font_config.use_pngquant:
+                        zopflipng_infile_fn = pngquant_dest
+                        nw.newline()
+                    write_compressed_bitmap_builds(
+                        zopflipng_builds,
+                        nw,
+                        master,
+                        rule_name="zopflipng",
+                        dest_dir=zopflipng_dir(),
+                        infile_fn=zopflipng_infile_fn,
+                        outfile_fn=zopflipng_dest,
+                    )
             nw.newline()
 
             for font_config in font_configs:

--- a/src/nanoemoji/pngquant.py
+++ b/src/nanoemoji/pngquant.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wrapper around pngquant command.
+
+This runs the pnquant command as a subprocess, forwarding all the unparsed options
+after '--', while also handling two special error codes 98 or 99 by simply copying the
+input file to the output file.
+Pngquant exits with 98 when the conversion results in a larger file than the original;
+and with 99 when the conversion results in quality below the requested minimum.
+
+Usage:
+
+    $ python -m nanoemoji.pngquant -i INPUT -o OUTPUT -- [PNGQUANTFLAGS]
+"""
+
+from absl import app
+from absl import flags
+import shlex
+import shutil
+import subprocess
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("input_file", None, "Input filename", short_name="i")
+flags.DEFINE_string("output_file", None, "Output filename", short_name="o")
+
+
+def main(argv):
+    pngquant = shutil.which("pngquant")
+    if pngquant is None:
+        raise RuntimeError(
+            "'pngquant' command-line tool not found on $PATH. "
+            "Try `pip install pngquant-cli` or visit https://github.com/kornelski/pngquant."
+        )
+    pngquant_args = argv[1:]
+    infile = FLAGS.input_file
+    outfile = FLAGS.output_file
+    p = subprocess.run([pngquant, *pngquant_args, "-o", outfile, infile])
+    err = p.returncode
+    if err in (98, 99):
+        print(f"Reuse {infile}")
+        shutil.copyfile(infile, outfile)
+        err = 0
+    return err
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("input_file")
+    flags.mark_flag_as_required("output_file")
+    app.run(main)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import subprocess
 import sys
+from functools import lru_cache
 from lxml import etree
 from fontTools import ttLib
 from nanoemoji import codepoints
@@ -285,6 +286,11 @@ def run_nanoemoji(args, tmp_dir=None):
     assert (tmp_dir / "build.ninja").is_file()
 
     return tmp_dir
+
+
+@lru_cache()
+def run_nanoemoji_memoized(args, tmp_dir=None):
+    return run_nanoemoji(args, tmp_dir=tmp_dir)
 
 
 _TEMPORARY_DIRS = set()


### PR DESCRIPTION
The pngquant command is now available as 'pngquant-cli' on PyPI so we can install it with pip like the rest of the dependencies: https://pypi.org/project/pngquant-cli

I still had to wrap the pngquant command with a script that handles two special error codes 98 (output larger than input) and 99 (conversion quality below minimum) by copying the input file to the output file. The [noto-emoji Makefile](https://github.com/googlefonts/noto-emoji/blob/9a5261d871451f9b5183c93483cbd68ed916b1e9/Makefile#L186) has a similar rule. If we don't add that, then a bunch of noto-emojis would fail to quantize (e.g. the standalone skin tone modifiers e.g. 🏽), as ninja sees the non-zero exit code and stops early.

I tried running this on my local machine and I now get a CBDT noto-emoji font which is around 10MB large (only 220KB larger than the original, not sure exactly where the extra bytes come from but I think it's a good start).

I'm going to add some tests that check that everything runs as expected