### PR TITLE
use pip to install resvg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,6 @@ jobs:
       with:
         python-version: ${{ matrix.config.python-version }}
 
-    - name: Install resvg
-      # We use a pre-compiled wheel because cargo install resvg takes too long:
-      # https://github.com/googlefonts/nanoemoji/pull/373
-      run: |
-        pip install --find-links https://github.com/anthrotype/resvg-wheels/releases/tag/v0.2.0 resvg
-        which resvg
-
     - name: Install tox
       run: pip install tox
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 # nanoemoji
-A wee tool to build color fonts, including the proposed [COLRv1](https://github.com/googlefonts/colr-gradients-spec/blob/main/colr-gradients-spec.md). Relies heavily on Skia via [picosvg](https://github.com/googlefonts/picosvg).
+A wee tool to build color fonts, including the proposed [COLRv1](https://github.com/googlefonts/colr-gradients-spec/blob/main/colr-gradients-spec.md). Relies heavily on Skia via [picosvg](https://github.com/googlefonts/picosvg), as well as [`resvg`](https://github.com/RazrFalcon/resvg) to rasterize SVG to PNG for the bitmap color formats.
 
 For example, to build a COLRv1 font with a focus on [handwriting](https://rsheeter.github.io/android_fonts/emoji.html?q=u:270d) do the following in a [venv](https://docs.python.org/3/library/venv.html):
 
@@ -23,10 +23,8 @@ Requires Python 3.7 or greater.
 | [COLRv1](https://docs.microsoft.com/en-us/typography/opentype/spec/colr#colr-formats) | Yes | x-glyph reuse |
 | [COLRv0](https://docs.microsoft.com/en-us/typography/opentype/spec/colr#colr-formats) | Yes | x-glyph reuse (limited), no gradients |
 | [SVG](https://docs.microsoft.com/en-us/typography/opentype/spec/svg) | Yes | x-glyph reuse |
-| [sbix](https://docs.microsoft.com/en-us/typography/opentype/spec/sbix) | Yes* | Only for Mac Safari due to https://github.com/harfbuzz/harfbuzz/issues/2679#issuecomment-1021419864. Only square bitmaps. Requires [`resvg`](https://github.com/RazrFalcon/resvg).|
-| [CBDT](https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt) | Yes* |  Only square bitmaps. Requires [`resvg`](https://github.com/RazrFalcon/resvg).|
-
-\* to use bitmap formats (sbix, CBDT) you must `cargo install resvg` or otherwise insure `resvg` is on PATH.
+| [sbix](https://docs.microsoft.com/en-us/typography/opentype/spec/sbix) | Yes | Only for Mac Safari due to https://github.com/harfbuzz/harfbuzz/issues/2679#issuecomment-1021419864. Only square bitmaps. Uses [`resvg`](https://github.com/RazrFalcon/resvg).|
+| [CBDT](https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt) | Yes |  Only square bitmaps. Uses [`resvg`](https://github.com/RazrFalcon/resvg).|
 
 ## Releasing
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "toml>=0.10.1",
         "ufo2ft[cffsubr]>=2.24.0",
         "ufoLib2>=0.6.2",
+        "resvg-cli>=0.22.0.post3",
         "zopfli>=0.2.1",
     ],
     extras_require=extras_require,

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -539,7 +539,7 @@ def _run(argv):
     if any(fc.has_bitmaps for fc in font_configs) and not shutil.which("resvg"):
         raise RuntimeError(
             "'resvg' command-line tool not found on $PATH. "
-            "Try `cargo install resvg` or visit https://github.com/RazrFalcon/resvg."
+            "Try `pip install resvg-cli` or visit https://github.com/RazrFalcon/resvg."
         )
 
     required_dirs = [build_dir()]

--- a/tests/nanoemoji_test.py
+++ b/tests/nanoemoji_test.py
@@ -34,7 +34,6 @@ from test_helper import (
     mkdtemp,
     cleanup_temp_dirs,
     run_nanoemoji,
-    RESVG_PATH,
 )
 
 
@@ -155,7 +154,6 @@ def _assert_table_size_cmp(table_tag, op, original_font, cmd):
     assert op(new_size, original_size)
 
 
-@pytest.mark.skipif(RESVG_PATH is None, reason="resvg not installed")
 @pytest.mark.parametrize("use_zopflipng", [True, False])
 def test_build_sbix_font(use_zopflipng):
     cmd = [locate_test_file("minimal_static/config_sbix.toml")]
@@ -169,7 +167,6 @@ def test_build_sbix_font(use_zopflipng):
         _assert_table_size_cmp("sbix", operator.gt, font, ["--nouse_zopflipng"] + cmd)
 
 
-@pytest.mark.skipif(RESVG_PATH is None, reason="resvg not installed")
 @pytest.mark.parametrize("use_zopflipng", [True, False])
 def test_build_cbdt_font(use_zopflipng):
     cmd = [locate_test_file("minimal_static/config_cbdt.toml")]
@@ -193,7 +190,6 @@ def test_build_cbdt_font(use_zopflipng):
     ],
 )
 @pytest.mark.parametrize("use_zopflipng", [True, False])
-@pytest.mark.skipif(RESVG_PATH is None, reason="resvg not installed")
 def test_build_compat_font(config_file, use_zopflipng):
     cmd = [locate_test_file(config_file)]
     tmp_dir = run_nanoemoji(cmd)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -34,9 +34,6 @@ import shutil
 import tempfile
 
 
-RESVG_PATH = shutil.which("resvg")
-
-
 def test_data_dir() -> Path:
     return Path(__file__).parent
 
@@ -259,12 +256,9 @@ def svg_diff(actual_svg: SVG, expected_svg: SVG):
 def run(cmd):
     cmd = tuple(str(c) for c in cmd)
     print("subprocess:", " ".join(cmd))  # very useful on failure
-    # We may need to find nanoemoji and (optionally) resvg
-    bin_paths = [str(Path(shutil.which("nanoemoji")).parent)]
-    if RESVG_PATH:
-        bin_paths.append(str(Path(RESVG_PATH).parent))
     env = {
-        "PATH": os.pathsep.join(bin_paths),
+        # We may need to find nanoemoji and other pip-installed cli tools
+        "PATH": str(Path(shutil.which("nanoemoji")).parent),
         # We may need to find test modules
         "PYTHONPATH": os.pathsep.join((str(Path(__file__).parent),)),
     }


### PR DESCRIPTION
resvg is now available on PyPI as https://pypi.org/project/resvg-cli so we can treat as any other python deps