### PR TITLE
color_glyph: remove assertion that width > 0

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -435,9 +435,6 @@ class ColorGlyph(NamedTuple):
             base_glyph.width = _advance_width(view_box, font_config)
         else:
             base_glyph.width = font_config.width
-        assert (
-            base_glyph.width > 0
-        ), f"0 width for {ufo_glyph_name} (svg {svg_filename}, bitmap {bitmap_filename})"
 
         # Setup direct access to the glyph if possible
         if len(codepoints) == 1:

--- a/tests/u0301.svg
+++ b/tests/u0301.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="glyph1" viewBox="0 0 0 1200">
+  <defs>
+    <linearGradient id="g0_0" x1="260.757" y1="303.433" x2="334.818" y2="62.853" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#BFBFBF"/>
+      <stop offset="1" stop-color="#404040"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#g0_0)" d="M186,310 L221,80 L397,80 L397,81 L282,310 L186,310 Z"/>
+</svg>


### PR DESCRIPTION
it's valid for fonts to have glyphs with zero advance width, e.g. combining marks

I stumbled on this while running `maximum_color` on a yet-to-be-published color font project, after exporting from Glyphs.app as an OT-SVG.

I wonder why the assertion was put that to begin with. Is it because when width is 0, a bitmap CBDT glyph would otherwise completely disappear (https://github.com/googlefonts/nanoemoji/issues/402)? 