### PR TITLE
Use precomputed part files for shape reuse

### DIFF
--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -472,23 +472,6 @@ class ColorGlyph(NamedTuple):
             )
         return view_box is not None
 
-    def _transform(self, map_fn):
-        if not self._has_viewbox_for_transform():
-            return Affine2D.identity()
-        return map_fn(
-            self.svg.view_box(),
-            self.ufo.info.ascender,
-            self.ufo.info.descender,
-            self.ufo_glyph.width,
-            self.user_transform,
-        )
-
-    def transform_for_otsvg_space(self):
-        return self._transform(map_viewbox_to_otsvg_space)
-
-    def transform_for_font_space(self):
-        return self._transform(map_viewbox_to_font_space)
-
     @property
     def ufo_glyph(self) -> UfoGlyph:
         return self.ufo[self.ufo_glyph_name]

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -158,7 +158,7 @@ class FontConfig(NamedTuple):
     transform: Affine2D = Affine2D.identity()
     version_major: int = 1
     version_minor: int = 0
-    reuse_tolerance: float = 0.1
+    reuse_tolerance: float = 0.05
     ignore_reuse_error: bool = True
     keep_glyph_names: bool = False
     clip_to_viewbox: bool = True

--- a/src/nanoemoji/extract_svgs_from_otsvg.py
+++ b/src/nanoemoji/extract_svgs_from_otsvg.py
@@ -19,7 +19,6 @@ from absl import logging
 from fontTools import ttLib
 from lxml import etree
 from nanoemoji import codepoints
-from nanoemoji.color_glyph import map_viewbox_to_otsvg_space
 from nanoemoji.extract_svgs import svg_glyphs
 from nanoemoji import util
 import os

--- a/src/nanoemoji/generate_svgs_from_colr.py
+++ b/src/nanoemoji/generate_svgs_from_colr.py
@@ -53,7 +53,9 @@ def main(argv):
     assert "COLR" in font, f"No COLR table in {font_file}"
     logging.debug("Writing svgs from %s to %s", font_file, out_dir)
 
-    for glyph_name, svg in colr_to_svg(lambda gn: _view_box(font, gn), font).items():
+    region_callback = lambda gn: _view_box(font, gn)
+
+    for glyph_name, svg in colr_to_svg(region_callback, region_callback, font).items():
         gid = font.getGlyphID(glyph_name)
         dest_file = out_dir / f"{gid:05d}.svg"
         with open(dest_file, "w") as f:

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -26,6 +26,7 @@ from nanoemoji.colors import Color
 from nanoemoji.fixed import (
     int16_safe,
     f2dot14_safe,
+    fixed_safe,
     MIN_INT16,
     MAX_INT16,
     MIN_UINT16,
@@ -761,14 +762,38 @@ def is_gradient(paint_or_format) -> bool:
     )
 
 
+def _int16_part(v) -> int:
+    if v < 0:
+        return max(v, MIN_INT16)
+    else:
+        return min(v, MAX_INT16)
+
+
 def transformed(transform: Affine2D, target: Paint) -> Paint:
-    if transform == Affine2D.identity():
+    if transform.almost_equals(Affine2D.identity()):
         return target
 
     sx, b, c, sy, dx, dy = transform
 
+    # Large translations (dx=50k) can occur due to use of big shapes
+    # to produce small shapes. Make a modest effort to work around.
+    if fixed_safe(sx, b, c, sy) and not fixed_safe(dx, dy):
+        dxt = _int16_part(dx)
+        dyt = _int16_part(dy)
+        dx -= dxt
+        dy -= dyt
+        if fixed_safe(dx, dy):
+            return PaintTranslate(
+                paint=transformed(Affine2D(sx, b, c, sy, dx, dy), target),
+                dx=dxt,
+                dy=dyt,
+            )
+        raise ValueError(f"Transform values are outlandishly large :( {transform}")
+
     # Int16 translation?
-    if (dx, dy) != (0, 0) and Affine2D.identity().translate(dx, dy) == transform:
+    if (dx, dy) != (0, 0) and Affine2D.identity().translate(dx, dy).almost_equals(
+        transform
+    ):
         if int16_safe(dx, dy):
             return PaintTranslate(paint=target, dx=dx, dy=dy)
 

--- a/src/nanoemoji/parts.py
+++ b/src/nanoemoji/parts.py
@@ -152,7 +152,7 @@ class ReusableParts:
             source.checkpicosvg()
             source_box = source.view_box()
             transform = scale_viewbox_to_font_metrics(
-                self.view_box, source_box.h, 0, source_box.w
+                source_box, self.view_box.h, 0, self.view_box.w
             )
             shapes = tuple(s.as_path() for s in source.shapes())
         else:

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -29,13 +29,14 @@ from fontTools.misc.roundTools import otRound
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.pens.boundsPen import ControlBoundsPen
 from fontTools.pens.transformPen import TransformPen
+import functools
 from itertools import chain
 from lxml import etree  # pytype: disable=import-error
 from nanoemoji.bitmap_tables import make_cbdt_table, make_sbix_table
 from nanoemoji import codepoints, config, glyphmap
 from nanoemoji.colors import Color
 from nanoemoji.config import FontConfig
-from nanoemoji.color_glyph import ColorGlyph
+from nanoemoji.color_glyph import ColorGlyph, map_viewbox_to_font_space
 from nanoemoji.fixed import fixed_safe
 from nanoemoji.glyph import glyph_name
 from nanoemoji.glyphmap import GlyphMapping
@@ -108,9 +109,12 @@ class InputGlyph(NamedTuple):
 # If the output file is .ufo then apply_ttfont is not called.
 # Where possible code to the ufo and let apply_ttfont be a nop.
 class ColorGenerator(NamedTuple):
-    apply_ufo: Callable[[FontConfig, ufoLib2.Font, Tuple[ColorGlyph, ...]], None]
+    apply_ufo: Callable[
+        [FontConfig, ReusableParts, ufoLib2.Font, Tuple[ColorGlyph, ...]], None
+    ]
     apply_ttfont: Callable[
-        [FontConfig, ufoLib2.Font, Tuple[ColorGlyph, ...], ttLib.TTFont], None
+        [FontConfig, ReusableParts, ufoLib2.Font, Tuple[ColorGlyph, ...], ttLib.TTFont],
+        None,
     ]
     font_ext: str  # extension for font binary, .ttf or .otf
 
@@ -263,82 +267,172 @@ def _next_name(ufo: ufoLib2.Font, name_fn) -> str:
     return name_fn(i)
 
 
-def _create_glyph(
-    color_glyph: ColorGlyph, paint: PaintGlyph, path_in_font_space: str
-) -> Glyph:
+def _create_glyph(color_glyph: ColorGlyph, path_in_font_space: str) -> Glyph:
     glyph = _init_glyph(color_glyph)
     ufo = color_glyph.ufo
     draw_svg_path(SVGPath(d=path_in_font_space), glyph.getPen())
     ufo.glyphOrder += [glyph.name]
+    print(glyph)
+    for contour in glyph.contours:
+        for i, pt in enumerate(contour.points):
+            print("  ", f"{i}:", pt)
     return glyph
 
 
-def _migrate_paths_to_ufo_glyphs(
-    color_glyph: ColorGlyph, glyph_cache: GlyphReuseCache
-) -> ColorGlyph:
-    svg_units_to_font_units = color_glyph.transform_for_font_space()
+def _svg_transform_in_font_space(
+    svg_units_to_font_units: Affine2D, transform: Affine2D
+) -> Affine2D:
+    # We have a transform in svg space to apply to a thing in font space
+    # Come back from font space, apply, and then return to font space
+    return Affine2D.compose_ltr(
+        (
+            svg_units_to_font_units.inverse(),
+            transform,
+            svg_units_to_font_units,
+        )
+    )
 
-    # Walk through the color glyph, where we see a PaintGlyph take the path out of it,
-    # move the path into font coordinates, generate a ufo glyph, and push the name of
-    # the ufo glyph into the PaintGlyph
-    def _update_paint_glyph(paint):
-        if paint.format != PaintGlyph.format:
-            return paint
 
-        if glyph_cache.is_known_glyph(paint.glyph):
-            return paint
+def _svg_units_to_font_units(
+    glyph_cache: GlyphReuseCache, config: FontConfig, glyph_width: int
+) -> Affine2D:
+    return map_viewbox_to_font_space(
+        glyph_cache.view_box(),
+        config.ascender,
+        config.descender,
+        glyph_width,
+        config.transform,
+    )
 
-        assert paint.glyph.startswith("M"), f"{paint.glyph} doesn't look like a path"
-        path_in_font_space = (
-            SVGPath(d=paint.glyph).apply_transform(svg_units_to_font_units).d
+
+def _create_glyph_for_svg_path(
+    config: FontConfig,
+    color_glyph: ColorGlyph,
+    glyph_cache: GlyphReuseCache,
+    path_in_svg_space: str,
+) -> Glyph:
+    svg_units_to_font_units = _svg_units_to_font_units(
+        glyph_cache, config, color_glyph.ufo_glyph.width
+    )
+    path_in_font_space = (
+        SVGPath(d=path_in_svg_space).apply_transform(svg_units_to_font_units).d
+    )
+    print(
+        "_create_glyph_for_svg_path, svg ",
+        path_in_svg_space,
+        "in",
+        glyph_cache.view_box(),
+    )
+    print("_create_glyph_for_svg_path, transform ", svg_units_to_font_units)
+    print("_create_glyph_for_svg_path, font", path_in_font_space)
+    glyph = _create_glyph(color_glyph, path_in_font_space)
+    glyph_cache.set_glyph_for_path(glyph.name, path_in_svg_space)
+    return glyph
+
+
+def _fix_nested_gradient(reuse_transform: Affine2D, paint: PaintGlyph) -> Paint:
+    # If we are applying a transform that can change downstream gradients in unwanted ways.
+    # If that seems likely, fix it.
+    child_transform = Affine2D.identity()
+    child_paint = paint.paint
+    if is_transform(child_paint):
+        child_transform = child_paint.gettransform()
+        child_paint = child_paint.paint  # pytype: disable=attribute-error
+
+    # TODO: handle gradient anywhere in subtree, not only as direct child of
+    # PaintGlyph or PaintTransform
+    if is_gradient(child_paint):
+        # We have a gradient so we need to reverse the effect of the
+        # maybe_reuse.transform. First we try to apply the combined transform
+        # to the gradient's geometry; but this may overflow OT integer bounds,
+        # in which case we pass through gradient unscaled
+        gradient_fix_transform = Affine2D.compose_ltr(
+            (child_transform, reuse_transform.inverse())
+        )
+        # skip reuse if combined transform overflows OT int bounds
+        if fixed_safe(*gradient_fix_transform):
+            try:
+                child_paint = child_paint.apply_transform(
+                    gradient_fix_transform
+                )  # pytype: disable=attribute-error
+            except OverflowError:
+                child_paint = transformed(gradient_fix_transform, child_paint)
+
+    return child_paint
+
+
+def _create_glyphs_for_svg_paths(
+    config: FontConfig,
+    color_glyph: ColorGlyph,
+    glyph_cache: GlyphReuseCache,
+    paint: Paint,
+):
+    """Create glyphs for unique paths and references for repeat encounters."""
+    if paint.format != PaintGlyph.format:
+        return paint
+
+    paint = cast(PaintGlyph, paint)
+
+    if glyph_cache.is_known_glyph(paint.glyph):
+        return paint
+
+    paint = cast(PaintGlyph, paint)
+    assert paint.glyph.startswith("M"), f"{paint.glyph} doesn't look like a path"
+    path_in_svg_space = paint.glyph
+
+    print("_create_glyphs_for_svg_paths")
+
+    maybe_reuse = glyph_cache.try_reuse(path_in_svg_space, color_glyph.svg.view_box())
+
+    # if we have a glyph for the target already, use that
+    if glyph_cache.is_known_path(maybe_reuse.shape):
+        paint = dataclasses.replace(
+            paint, glyph=glyph_cache.get_glyph_for_path(maybe_reuse.shape)
+        )
+    else:
+        # TODO: when is it more compact to use a new transforming glyph?
+        # otherwise, create a glyph for the target and use it
+        print("  ", "create glyph for", maybe_reuse.shape)
+        glyph = _create_glyph_for_svg_path(
+            config, color_glyph, glyph_cache, maybe_reuse.shape
+        )
+        paint = dataclasses.replace(paint, glyph=glyph.name)
+
+    if not maybe_reuse.transform.almost_equals(Affine2D.identity()):
+        # TODO: when is it more compact to use a new transforming glyph?
+
+        svg_units_to_font_units = _svg_units_to_font_units(
+            glyph_cache, config, color_glyph.ufo_glyph.width
+        )
+        reuse_transform = _svg_transform_in_font_space(
+            svg_units_to_font_units, maybe_reuse.transform
         )
 
-        reuse_result = glyph_cache.try_reuse(path_in_font_space)
-        if reuse_result is not None:
-            # TODO: when is it more compact to use a new transforming glyph?
-            child_transform = Affine2D.identity()
-            child_paint = paint.paint
-            if is_transform(child_paint):
-                child_transform = child_paint.gettransform()
-                child_paint = child_paint.paint
+        print("  ", "reuse, maybe_reuse.transform", maybe_reuse.transform)
+        print("  ", "reuse, svg_units_to_font_units", svg_units_to_font_units)
+        print("  ", "reuse, reuse_transform", reuse_transform)
+        # assert fixed_safe(*reuse_transform), f"{color_glyph.svg_filename} {color_glyph.ufo_glyph_name} fixed unsafe {reuse_transform} to reuse {maybe_reuse.shape} for {path_in_svg_space}"
 
-            # sanity check: GlyphReuseCache.try_reuse would return None if overflowed
-            assert fixed_safe(*reuse_result.transform)
-            overflows = False
+        # might need to adjust a gradient
+        child_paint = _fix_nested_gradient(reuse_transform, paint)
+        if paint.paint is not child_paint:
+            paint = dataclasses.replace(paint, paint=child_paint)
 
-            # TODO: handle gradient anywhere in subtree, not only as direct child of
-            # PaintGlyph or PaintTransform
-            if is_gradient(child_paint):
-                # We have a gradient so we need to reverse the effect of the
-                # reuse_result.transform. First we try to apply the combined transform
-                # to the gradient's geometry; but this may overflow OT integer bounds,
-                # in which case we pass through gradient unscaled
-                transform = Affine2D.compose_ltr(
-                    (child_transform, reuse_result.transform.inverse())
-                )
-                # skip reuse if combined transform overflows OT int bounds
-                overflows = not fixed_safe(*transform)
-                if not overflows:
-                    try:
-                        child_paint = child_paint.apply_transform(transform)
-                    except OverflowError:
-                        child_paint = transformed(transform, child_paint)
+        paint = transformed(reuse_transform, paint)
 
-            if not overflows:
-                return transformed(
-                    reuse_result.transform,
-                    PaintGlyph(
-                        glyph=reuse_result.glyph_name,
-                        paint=child_paint,
-                    ),
-                )
+    return paint
 
-        glyph = _create_glyph(color_glyph, paint, path_in_font_space)
-        glyph_cache.add_glyph(glyph.name, path_in_font_space)
 
-        return dataclasses.replace(paint, glyph=glyph.name)
-
-    return color_glyph.mutating_traverse(_update_paint_glyph)
+def _migrate_paths_to_ufo_glyphs(
+    config: FontConfig, color_glyph: ColorGlyph, glyph_cache: GlyphReuseCache
+) -> ColorGlyph:
+    # Initially PaintGlyph's have paths not glyph names.
+    # We need to create all the unique paths as ufo glyphs and assign glyph names.
+    return color_glyph.mutating_traverse(
+        functools.partial(
+            _create_glyphs_for_svg_paths, config, color_glyph, glyph_cache
+        )
+    )
 
 
 def _draw_glyph_extents(
@@ -378,26 +472,28 @@ def _draw_notdef(config: FontConfig, ufo: ufoLib2.Font):
 
 
 def _glyf_ufo(
-    config: FontConfig, ufo: ufoLib2.Font, color_glyphs: Tuple[ColorGlyph, ...]
+    config: FontConfig,
+    reusable_parts: ReusableParts,
+    ufo: ufoLib2.Font,
+    color_glyphs: Tuple[ColorGlyph, ...],
 ):
     # We want to mutate our view of color_glyphs
     color_glyphs = list(color_glyphs)
 
     # glyphs by reuse_key
-    glyph_cache = GlyphReuseCache(config.reuse_tolerance)
+    glyph_cache = GlyphReuseCache(reusable_parts)
     glyph_uses = Counter()
     for i, color_glyph in enumerate(color_glyphs):
         logging.debug(
             "%s %s %s",
             ufo.info.familyName,
             color_glyph.ufo_glyph_name,
-            color_glyph.transform_for_font_space(),
         )
         parent_glyph = color_glyph.ufo_glyph
 
         # generate glyphs for PaintGlyph's and assign glyph names
         color_glyphs[i] = color_glyph = _migrate_paths_to_ufo_glyphs(
-            color_glyph, glyph_cache
+            config, color_glyph, glyph_cache
         )
 
         for root in color_glyph.painted_layers:
@@ -450,6 +546,7 @@ def _create_transformed_glyph(
     glyph = _init_glyph(color_glyph)
     glyph.components.append(Component(baseGlyph=paint.glyph, transformation=transform))
     color_glyph.ufo.glyphOrder += [glyph.name]
+    print("_create_transformed_glyph", glyph.name, transform)
     return glyph
 
 
@@ -570,6 +667,7 @@ def _ufo_colr_layers(
 def _colr_ufo(
     colr_version: int,
     config: FontConfig,
+    reusable_parts: ReusableParts,
     ufo: ufoLib2.Font,
     color_glyphs: Tuple[ColorGlyph, ...],
 ):
@@ -601,7 +699,7 @@ def _colr_ufo(
     ufo_color_layers = {}
 
     # potentially reusable glyphs
-    glyph_cache = GlyphReuseCache(config.reuse_tolerance)
+    glyph_cache = GlyphReuseCache(reusable_parts)
 
     clipBoxes = {}
     quantization = config.clipbox_quantization
@@ -610,15 +708,14 @@ def _colr_ufo(
         quantization = round(config.upem * 0.02)
     for i, color_glyph in enumerate(color_glyphs):
         logging.debug(
-            "%s %s %s",
+            "%s %s",
             ufo.info.familyName,
             color_glyph.ufo_glyph_name,
-            color_glyph.transform_for_font_space(),
         )
 
         # generate glyphs for PaintGlyph's and assign glyph names
         color_glyphs[i] = color_glyph = _migrate_paths_to_ufo_glyphs(
-            color_glyph, glyph_cache
+            config, color_glyph, glyph_cache
         )
 
         if color_glyph.painted_layers:
@@ -650,44 +747,37 @@ def _colr_ufo(
 
 def _sbix_ttfont(
     config: FontConfig,
-    _,
+    reusable_parts: ReusableParts,
+    ufo: ufoLib2.Font,
     color_glyphs: Tuple[ColorGlyph, ...],
     ttfont: ttLib.TTFont,
 ):
+    del reusable_parts, ufo
     make_sbix_table(config, ttfont, color_glyphs)
 
 
 def _cbdt_ttfont(
     config: FontConfig,
-    _,
+    reusable_parts: ReusableParts,
+    ufo: ufoLib2.Font,
     color_glyphs: Tuple[ColorGlyph, ...],
     ttfont: ttLib.TTFont,
 ):
+    del reusable_parts, ufo
     make_cbdt_table(config, ttfont, color_glyphs)
 
 
 def _svg_ttfont(
     config: FontConfig,
-    _,
+    reusable_parts: ReusableParts,
+    ufo: ufoLib2.Font,
     color_glyphs: Tuple[ColorGlyph, ...],
     ttfont: ttLib.TTFont,
     picosvg: bool = True,
     compressed: bool = False,
 ):
-    make_svg_table(config, ttfont, color_glyphs, picosvg, compressed)
-
-
-def _picosvg_and_cbdt(
-    config: FontConfig,
-    _,
-    color_glyphs: Tuple[ColorGlyph, ...],
-    ttfont: ttLib.TTFont,
-):
-    picosvg = True
-    compressed = False
-    # make the svg table first because it changes glyph order and cbdt cares
-    make_svg_table(config, ttfont, color_glyphs, picosvg, compressed)
-    make_cbdt_table(config, ttfont, color_glyphs)
+    del ufo
+    make_svg_table(config, reusable_parts, ttfont, color_glyphs, picosvg, compressed)
 
 
 def _ensure_codepoints_will_have_glyphs(ufo, glyph_inputs):
@@ -718,8 +808,11 @@ def _ensure_codepoints_will_have_glyphs(ufo, glyph_inputs):
     ufo.glyphOrder = ufo.glyphOrder + sorted(glyph_names)
 
 
-def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
+def _generate_color_font(
+    config: FontConfig, reusable_parts: ReusableParts, inputs: Iterable[InputGlyph]
+):
     """Make a UFO and optionally a TTFont from svgs."""
+    print("_generate_color_font", "upem", config.upem)
     ufo = _ufo(config)
     _ensure_codepoints_will_have_glyphs(ufo, inputs)
 
@@ -757,7 +850,9 @@ def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
             g.glyph_id == ufo_gid
         ), f"{g.ufo_glyph_name} is {ufo_gid} in ufo, {g.glyph_id} in ColorGlyph"
 
-    _COLOR_FORMAT_GENERATORS[config.color_format].apply_ufo(config, ufo, color_glyphs)
+    _COLOR_FORMAT_GENERATORS[config.color_format].apply_ufo(
+        config, reusable_parts, ufo, color_glyphs
+    )
 
     if config.fea_file:
         with open(config.fea_file) as f:
@@ -774,7 +869,7 @@ def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
 
         # Permit fixups where we can't express something adequately in UFO
         _COLOR_FORMAT_GENERATORS[config.color_format].apply_ttfont(
-            config, ufo, color_glyphs, ttfont
+            config, reusable_parts, ufo, color_glyphs, ttfont
         )
 
         # some formats keep glyph order through to here
@@ -825,14 +920,14 @@ def main(argv):
         )
 
     inputs = list(_inputs(font_config, glyphmap.parse_csv(FLAGS.glyphmap_file)))
+    if not inputs:
+        sys.exit("Please provide at least one svg filename")
 
     reusable_parts = ReusableParts()
     if FLAGS.part_file:
         reusable_parts = ReusableParts.loadjson(Path(FLAGS.part_file))
 
-    if not inputs:
-        sys.exit("Please provide at least one svg filename")
-    ufo, ttfont = _generate_color_font(font_config, inputs)
+    ufo, ttfont = _generate_color_font(font_config, reusable_parts, inputs)
     _write(ufo, ttfont, font_config.output_file)
     logging.info("Wrote %s" % font_config.output_file)
 

--- a/tests/clocks_colr_1.ttx
+++ b/tests/clocks_colr_1.ttx
@@ -290,8 +290,8 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.117"/>
-          <dx value="44.167"/>
-          <dy value="44.167"/>
+          <dx value="44.16641"/>
+          <dy value="44.13359"/>
         </Transform>
       </Paint>
       <Paint index="4" Format="22"><!-- PaintScaleUniformAroundCenter -->
@@ -319,8 +319,8 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.067"/>
-          <dx value="9.081"/>
-          <dy value="46.565"/>
+          <dx value="9.08047"/>
+          <dy value="46.53203"/>
         </Transform>
       </Paint>
       <Paint index="6" Format="12"><!-- PaintTransform -->
@@ -336,8 +336,8 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.067"/>
-          <dx value="46.581"/>
-          <dy value="84.065"/>
+          <dx value="46.58047"/>
+          <dy value="84.03203"/>
         </Transform>
       </Paint>
       <Paint index="7" Format="12"><!-- PaintTransform -->
@@ -353,8 +353,8 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.067"/>
-          <dx value="46.581"/>
-          <dy value="9.065"/>
+          <dx value="46.58047"/>
+          <dy value="9.03203"/>
         </Transform>
       </Paint>
       <Paint index="8" Format="12"><!-- PaintTransform -->
@@ -370,8 +370,8 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.067"/>
-          <dx value="84.081"/>
-          <dy value="46.565"/>
+          <dx value="84.08047"/>
+          <dy value="46.53203"/>
         </Transform>
       </Paint>
       <Paint index="9" Format="10"><!-- PaintGlyph -->

--- a/tests/clocks_colr_1_noreuse.ttx
+++ b/tests/clocks_colr_1_noreuse.ttx
@@ -18,15 +18,6 @@
     <GlyphID id="12" name="e000.8"/>
     <GlyphID id="13" name="e000.9"/>
     <GlyphID id="14" name="e001.0"/>
-    <GlyphID id="15" name="e001.1"/>
-    <GlyphID id="16" name="e001.2"/>
-    <GlyphID id="17" name="e001.3"/>
-    <GlyphID id="18" name="e001.4"/>
-    <GlyphID id="19" name="e001.5"/>
-    <GlyphID id="20" name="e001.6"/>
-    <GlyphID id="21" name="e001.7"/>
-    <GlyphID id="22" name="e001.8"/>
-    <GlyphID id="23" name="e001.9"/>
   </GlyphOrder>
 
   <hmtx>
@@ -44,16 +35,7 @@
     <mtx name="e000.8" width="100" lsb="84"/>
     <mtx name="e000.9" width="100" lsb="3"/>
     <mtx name="e001" width="100" lsb="0"/>
-    <mtx name="e001.0" width="100" lsb="3"/>
-    <mtx name="e001.1" width="100" lsb="47"/>
-    <mtx name="e001.2" width="100" lsb="49"/>
-    <mtx name="e001.3" width="100" lsb="45"/>
-    <mtx name="e001.4" width="100" lsb="48"/>
-    <mtx name="e001.5" width="100" lsb="9"/>
-    <mtx name="e001.6" width="100" lsb="47"/>
-    <mtx name="e001.7" width="100" lsb="47"/>
-    <mtx name="e001.8" width="100" lsb="84"/>
-    <mtx name="e001.9" width="100" lsb="3"/>
+    <mtx name="e001.0" width="100" lsb="49"/>
   </hmtx>
 
   <cmap>
@@ -329,55 +311,7 @@
 
     <TTGlyph name="e001"/><!-- contains no outline data -->
 
-    <TTGlyph name="e001.0" xMin="3" yMin="3" xMax="97" yMax="97">
-      <contour>
-        <pt x="97" y="50" on="1"/>
-        <pt x="97" y="60" on="0"/>
-        <pt x="90" y="77" on="0"/>
-        <pt x="77" y="90" on="0"/>
-        <pt x="60" y="97" on="0"/>
-        <pt x="50" y="97" on="1"/>
-        <pt x="40" y="97" on="0"/>
-        <pt x="23" y="90" on="0"/>
-        <pt x="10" y="77" on="0"/>
-        <pt x="3" y="60" on="0"/>
-        <pt x="3" y="50" on="1"/>
-        <pt x="3" y="40" on="0"/>
-        <pt x="10" y="23" on="0"/>
-        <pt x="23" y="10" on="0"/>
-        <pt x="40" y="3" on="0"/>
-        <pt x="50" y="3" on="1"/>
-        <pt x="60" y="3" on="0"/>
-        <pt x="77" y="10" on="0"/>
-        <pt x="90" y="23" on="0"/>
-        <pt x="97" y="40" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.1" xMin="47" yMin="50" xMax="53" yMax="81">
-      <contour>
-        <pt x="50" y="50" on="1"/>
-        <pt x="49" y="50" on="0"/>
-        <pt x="47" y="52" on="0"/>
-        <pt x="47" y="53" on="1"/>
-        <pt x="47" y="78" on="1"/>
-        <pt x="47" y="80" on="0"/>
-        <pt x="49" y="81" on="0"/>
-        <pt x="50" y="81" on="1"/>
-        <pt x="50" y="81" on="1"/>
-        <pt x="51" y="81" on="0"/>
-        <pt x="53" y="80" on="0"/>
-        <pt x="53" y="78" on="1"/>
-        <pt x="53" y="53" on="1"/>
-        <pt x="53" y="52" on="0"/>
-        <pt x="51" y="50" on="0"/>
-        <pt x="50" y="50" on="1"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.2" xMin="49" yMin="48" xMax="71" yMax="63">
+    <TTGlyph name="e001.0" xMin="49" yMin="48" xMax="71" yMax="63">
       <contour>
         <pt x="50" y="50" on="1"/>
         <pt x="49" y="51" on="0"/>
@@ -395,164 +329,6 @@
         <pt x="53" y="48" on="0"/>
         <pt x="51" y="49" on="0"/>
         <pt x="50" y="50" on="1"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.3" xMin="45" yMin="45" xMax="55" yMax="55">
-      <contour>
-        <pt x="55" y="50" on="1"/>
-        <pt x="55" y="52" on="0"/>
-        <pt x="52" y="55" on="0"/>
-        <pt x="50" y="55" on="1"/>
-        <pt x="48" y="55" on="0"/>
-        <pt x="45" y="52" on="0"/>
-        <pt x="45" y="50" on="1"/>
-        <pt x="45" y="48" on="0"/>
-        <pt x="48" y="45" on="0"/>
-        <pt x="50" y="45" on="1"/>
-        <pt x="52" y="45" on="0"/>
-        <pt x="55" y="48" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.4" xMin="48" yMin="48" xMax="52" yMax="52">
-      <contour>
-        <pt x="52" y="50" on="1"/>
-        <pt x="52" y="51" on="0"/>
-        <pt x="51" y="52" on="0"/>
-        <pt x="50" y="52" on="1"/>
-        <pt x="49" y="52" on="0"/>
-        <pt x="48" y="51" on="0"/>
-        <pt x="48" y="50" on="1"/>
-        <pt x="48" y="49" on="0"/>
-        <pt x="49" y="48" on="0"/>
-        <pt x="50" y="48" on="1"/>
-        <pt x="51" y="48" on="0"/>
-        <pt x="52" y="49" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.5" xMin="9" yMin="47" xMax="16" yMax="53">
-      <contour>
-        <pt x="16" y="50" on="1"/>
-        <pt x="16" y="51" on="0"/>
-        <pt x="14" y="53" on="0"/>
-        <pt x="12" y="53" on="1"/>
-        <pt x="11" y="53" on="0"/>
-        <pt x="9" y="51" on="0"/>
-        <pt x="9" y="50" on="1"/>
-        <pt x="9" y="49" on="0"/>
-        <pt x="11" y="47" on="0"/>
-        <pt x="12" y="47" on="1"/>
-        <pt x="14" y="47" on="0"/>
-        <pt x="16" y="49" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.6" xMin="47" yMin="84" xMax="53" yMax="91">
-      <contour>
-        <pt x="53" y="87" on="1"/>
-        <pt x="53" y="89" on="0"/>
-        <pt x="51" y="91" on="0"/>
-        <pt x="50" y="91" on="1"/>
-        <pt x="49" y="91" on="0"/>
-        <pt x="47" y="89" on="0"/>
-        <pt x="47" y="87" on="1"/>
-        <pt x="47" y="86" on="0"/>
-        <pt x="49" y="84" on="0"/>
-        <pt x="50" y="84" on="1"/>
-        <pt x="51" y="84" on="0"/>
-        <pt x="53" y="86" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.7" xMin="47" yMin="9" xMax="53" yMax="16">
-      <contour>
-        <pt x="53" y="12" on="1"/>
-        <pt x="53" y="14" on="0"/>
-        <pt x="51" y="16" on="0"/>
-        <pt x="50" y="16" on="1"/>
-        <pt x="49" y="16" on="0"/>
-        <pt x="47" y="14" on="0"/>
-        <pt x="47" y="12" on="1"/>
-        <pt x="47" y="11" on="0"/>
-        <pt x="49" y="9" on="0"/>
-        <pt x="50" y="9" on="1"/>
-        <pt x="51" y="9" on="0"/>
-        <pt x="53" y="11" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.8" xMin="84" yMin="47" xMax="91" yMax="53">
-      <contour>
-        <pt x="91" y="50" on="1"/>
-        <pt x="91" y="51" on="0"/>
-        <pt x="89" y="53" on="0"/>
-        <pt x="87" y="53" on="1"/>
-        <pt x="86" y="53" on="0"/>
-        <pt x="84" y="51" on="0"/>
-        <pt x="84" y="50" on="1"/>
-        <pt x="84" y="49" on="0"/>
-        <pt x="86" y="47" on="0"/>
-        <pt x="87" y="47" on="1"/>
-        <pt x="89" y="47" on="0"/>
-        <pt x="91" y="49" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="e001.9" xMin="3" yMin="3" xMax="97" yMax="97">
-      <contour>
-        <pt x="50" y="94" on="1"/>
-        <pt x="41" y="94" on="0"/>
-        <pt x="25" y="87" on="0"/>
-        <pt x="13" y="75" on="0"/>
-        <pt x="6" y="59" on="0"/>
-        <pt x="6" y="50" on="1"/>
-        <pt x="6" y="41" on="0"/>
-        <pt x="13" y="25" on="0"/>
-        <pt x="25" y="13" on="0"/>
-        <pt x="41" y="6" on="0"/>
-        <pt x="50" y="6" on="1"/>
-        <pt x="59" y="6" on="0"/>
-        <pt x="75" y="13" on="0"/>
-        <pt x="87" y="25" on="0"/>
-        <pt x="94" y="41" on="0"/>
-        <pt x="94" y="50" on="1"/>
-        <pt x="94" y="59" on="0"/>
-        <pt x="87" y="75" on="0"/>
-        <pt x="75" y="87" on="0"/>
-        <pt x="59" y="94" on="0"/>
-        <pt x="50" y="94" on="1"/>
-      </contour>
-      <contour>
-        <pt x="50" y="97" on="1"/>
-        <pt x="50" y="97" on="1"/>
-        <pt x="60" y="97" on="0"/>
-        <pt x="77" y="90" on="0"/>
-        <pt x="90" y="77" on="0"/>
-        <pt x="97" y="60" on="0"/>
-        <pt x="97" y="50" on="1"/>
-        <pt x="97" y="40" on="0"/>
-        <pt x="90" y="23" on="0"/>
-        <pt x="77" y="10" on="0"/>
-        <pt x="60" y="3" on="0"/>
-        <pt x="50" y="3" on="1"/>
-        <pt x="40" y="3" on="0"/>
-        <pt x="23" y="10" on="0"/>
-        <pt x="10" y="23" on="0"/>
-        <pt x="3" y="40" on="0"/>
-        <pt x="3" y="50" on="1"/>
-        <pt x="3" y="60" on="0"/>
-        <pt x="10" y="77" on="0"/>
-        <pt x="23" y="90" on="0"/>
-        <pt x="40" y="97" on="0"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -575,13 +351,13 @@
       <BaseGlyphPaintRecord index="1">
         <BaseGlyph value="e001"/>
         <Paint Format="1"><!-- PaintColrLayers -->
-          <NumLayers value="10"/>
+          <NumLayers value="4"/>
           <FirstLayerIndex value="10"/>
         </Paint>
       </BaseGlyphPaintRecord>
     </BaseGlyphList>
     <LayerList>
-      <!-- LayerCount=20 -->
+      <!-- LayerCount=14 -->
       <Paint index="0" Format="10"><!-- PaintGlyph -->
         <Paint Format="4"><!-- PaintLinearGradient -->
           <ColorLine>
@@ -693,70 +469,25 @@
           <x2 value="-22"/>
           <y2 value="85"/>
         </Paint>
-        <Glyph value="e001.0"/>
+        <Glyph value="e000.0"/>
       </Paint>
       <Paint index="11" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <PaletteIndex value="4"/>
           <Alpha value="1.0"/>
         </Paint>
-        <Glyph value="e001.1"/>
+        <Glyph value="e000.1"/>
       </Paint>
       <Paint index="12" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
           <PaletteIndex value="7"/>
           <Alpha value="1.0"/>
         </Paint>
-        <Glyph value="e001.2"/>
+        <Glyph value="e001.0"/>
       </Paint>
-      <Paint index="13" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="2"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.3"/>
-      </Paint>
-      <Paint index="14" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="8"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.4"/>
-      </Paint>
-      <Paint index="15" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="3"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.5"/>
-      </Paint>
-      <Paint index="16" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="3"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.6"/>
-      </Paint>
-      <Paint index="17" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="3"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.7"/>
-      </Paint>
-      <Paint index="18" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="3"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e001.8"/>
-      </Paint>
-      <Paint index="19" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="2"/>
-          <Alpha value="0.2"/>
-        </Paint>
-        <Glyph value="e001.9"/>
+      <Paint index="13" Format="1"><!-- PaintColrLayers -->
+        <NumLayers value="7"/>
+        <FirstLayerIndex value="3"/>
       </Paint>
     </LayerList>
     <ClipList Format="1">

--- a/tests/color_glyph_test.py
+++ b/tests/color_glyph_test.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from nanoemoji.colors import Color
-from nanoemoji.color_glyph import ColorGlyph
+from nanoemoji.color_glyph import map_viewbox_to_font_space, ColorGlyph
 from nanoemoji.config import FontConfig
 from nanoemoji.paint import *
+from picosvg.geometric_types import Rect
 from picosvg.svg import SVG
 from picosvg.svg_transform import Affine2D
 import dataclasses
@@ -126,7 +127,16 @@ def test_transform_and_width(
         config, ufo, "duck", 1, "glyph_name", [0x0042], SVG.fromstring(svg_str)
     )
 
-    assert color_glyph.transform_for_font_space() == pytest.approx(expected_transform)
+    assert (
+        map_viewbox_to_font_space(
+            Rect(*(int(s) for s in view_box.split(" "))),
+            ufo.info.ascender,
+            ufo.info.descender,
+            color_glyph.ufo_glyph.width,
+            config.transform,
+        )
+        == pytest.approx(expected_transform)
+    )
     assert ufo[color_glyph.ufo_glyph_name].width == expected_width
 
 

--- a/tests/glyph_reuse_test.py
+++ b/tests/glyph_reuse_test.py
@@ -14,9 +14,66 @@
 
 
 from nanoemoji.config import _DEFAULT_CONFIG
-from nanoemoji.glyph_reuse import GlyphReuseCache, ReuseResult
+from nanoemoji.glyph_reuse import GlyphReuseCache
+from nanoemoji.parts import as_shape, ReuseResult, ReusableParts
+from picosvg.geometric_types import Rect
+from picosvg.svg import SVG
 from picosvg.svg_transform import Affine2D
+from picosvg.svg_types import SVGPath
 import pytest
+
+
+def _svg(view_box, *paths):
+    raw_svg = f'<svg viewBox="{" ".join(str(v) for v in view_box)}" xmlns="http://www.w3.org/2000/svg">\n'
+    for path in paths:
+        raw_svg += f'  <path d="{path}" />\n'
+    raw_svg += "</svg>"
+    print(raw_svg)
+    return SVG.fromstring(raw_svg)
+
+
+# https://github.com/googlefonts/nanoemoji/issues/313: fixed by ReusableParts.
+# Previously if small was seen first no solution.
+def test_small_then_large_circle():
+
+    small_circle = "M818.7666015625,133.60003662109375 C818.7666015625,130.28631591796875 816.080322265625,127.5999755859375 812.7666015625,127.5999755859375 C809.4529418945312,127.5999755859375 806.7666015625,130.28631591796875 806.7666015625,133.60003662109375 C806.7666015625,136.9136962890625 809.4529418945312,139.60003662109375 812.7666015625,139.60003662109375 C816.080322265625,139.60003662109375 818.7666015625,136.9136962890625 818.7666015625,133.60003662109375 Z"
+    large_circle = "M1237.5,350 C1237.5,18.629150390625 968.870849609375,-250 637.5,-250 C306.1291198730469,-250 37.5,18.629150390625 37.5,350 C37.5,681.370849609375 306.1291198730469,950 637.5,950 C968.870849609375,950 1237.5,681.370849609375 1237.5,350 Z"
+
+    view_box = Rect(0, 0, 1024, 1024)
+    svg = _svg(
+        view_box,
+        # small circle, encountered first
+        small_circle,
+        # large circle, encountered second
+        large_circle,
+    )
+
+    parts = ReusableParts(_DEFAULT_CONFIG.reuse_tolerance, view_box=view_box)
+    parts.add(svg)
+    parts.compute_donors()
+
+    assert (
+        len(parts.shape_sets) == 1
+    ), f"Did not normalize the same :( \n{parts.to_json()}"
+
+    # should both have a solution
+    solutions = (
+        parts.try_reuse(SVGPath(d=small_circle)),
+        parts.try_reuse(SVGPath(d=large_circle)),
+    )
+    assert all(s is not None for s in solutions), parts.to_json()
+
+    # exactly one should have identity, the other ... not
+    assert (
+        len([s for s in solutions if s.transform.almost_equals(Affine2D.identity())])
+        == 1
+    ), parts.to_json()
+    assert (
+        len(
+            [s for s in solutions if not s.transform.almost_equals(Affine2D.identity())]
+        )
+        == 1
+    ), parts.to_json()
 
 
 # Not try to fully exercise affine_between, just to sanity check things somewhat work
@@ -24,19 +81,27 @@ import pytest
     "path_a, path_b, expected_result",
     [
         (
-            "M-1,-1 L 0,1 L 1, -1 z",
-            "M-2,-2 L 0,2 L 2, -2 z",
-            ReuseResult(glyph_name="A", transform=Affine2D.identity().scale(2)),
-        ),
-        # https://github.com/googlefonts/nanoemoji/issues/313
-        (
-            "M818.7666015625,133.60003662109375 C818.7666015625,130.28631591796875 816.080322265625,127.5999755859375 812.7666015625,127.5999755859375 C809.4529418945312,127.5999755859375 806.7666015625,130.28631591796875 806.7666015625,133.60003662109375 C806.7666015625,136.9136962890625 809.4529418945312,139.60003662109375 812.7666015625,139.60003662109375 C816.080322265625,139.60003662109375 818.7666015625,136.9136962890625 818.7666015625,133.60003662109375 Z",
-            "M1237.5,350 C1237.5,18.629150390625 968.870849609375,-250 637.5,-250 C306.1291198730469,-250 37.5,18.629150390625 37.5,350 C37.5,681.370849609375 306.1291198730469,950 637.5,950 C968.870849609375,950 1237.5,681.370849609375 1237.5,350 Z",
-            None,
+            "M-2,-2 L0,2 L2,-2 z",
+            "M-1,-1 L0,1 L1,-1 z",
+            ReuseResult(
+                transform=Affine2D.identity().scale(0.5),
+                shape=as_shape(SVGPath(d="M-2,-2 L0,2 L2,-2 z")),
+            ),
         ),
     ],
 )
 def test_glyph_reuse_cache(path_a, path_b, expected_result):
-    reuse_cache = GlyphReuseCache(_DEFAULT_CONFIG.reuse_tolerance)
-    reuse_cache.add_glyph("A", path_a)
-    assert reuse_cache.try_reuse(path_b) == expected_result
+    view_box = Rect(0, 0, 10, 10)
+    svg = _svg(
+        view_box,
+        path_a,
+        path_b,
+    )
+
+    parts = ReusableParts(_DEFAULT_CONFIG.reuse_tolerance, view_box=view_box)
+    parts.add(svg)
+    reuse_cache = GlyphReuseCache(parts)
+    reuse_cache.set_glyph_for_path("A", path_a)
+    reuse_cache.set_glyph_for_path("B", path_b)
+
+    assert reuse_cache.try_reuse(path_b, view_box) == expected_result

--- a/tests/group_opacity_reuse_picosvg.ttx
+++ b/tests/group_opacity_reuse_picosvg.ttx
@@ -60,11 +60,14 @@
   <SVG>
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+  <defs>
+    <path d="M40,30 L100,30 L100,50 L40,50 L40,30 Z" id="e000.0"/>
+  </defs>
   <g id="glyph2" transform="matrix(0.781 0 0 0.781 0 -100)">
-    <path d="M60,10 L80,10 L80,60 L60,60 L60,10 Z" id="e000.0"/>
+    <use xlink:href="#e000.0" transform="matrix(0.333 0 0 2.5 46.667 -65)"/>
     <g opacity="0.6">
-      <use xlink:href="#e000.0" x="-280" y="16" transform="matrix(5 0 0 0.4 1120 9.6)" fill="red"/>
-      <use xlink:href="#e000.0" x="-140" y="26" transform="matrix(3 0 0 0.4 280 15.6)" fill="blue"/>
+      <path d="M20,20 L120,20 L120,40 L20,40 L20,20 Z" fill="red"/>
+      <use xlink:href="#e000.0" fill="blue"/>
     </g>
   </g>
 </svg>

--- a/tests/nanoemoji_test.py
+++ b/tests/nanoemoji_test.py
@@ -68,10 +68,10 @@ def test_build_static_font_default_config_cli_svg_list():
 
 def _build_and_check_ttx(config_overrides, svgs, expected_ttx):
     config_file = mkdtemp() / "config.toml"
-    font_config, glyph_inputs = color_font_config(
+    font_config, parts, glyph_inputs = color_font_config(
         config_overrides, svgs, tmp_dir=config_file.parent
     )
-    del glyph_inputs
+    del parts, glyph_inputs
     config.write(config_file, font_config)
     print(config_file, font_config)
 

--- a/tests/omit_empty_color_glyphs_svg.ttx
+++ b/tests/omit_empty_color_glyphs_svg.ttx
@@ -55,8 +55,8 @@
   <SVG>
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-  <g id="glyph2" transform="matrix(120 0 0 120 37.5 -950)">
-    <path d="M4,4 L8,4 L8,8 L4,8 L4,4 Z" fill="orange"/>
+  <g id="glyph2" transform="translate(37.5, -950)">
+    <path d="M480,480 L960,480 L960,960 L480,960 L480,480 Z" fill="orange"/>
   </g>
 </svg>
 ]]>

--- a/tests/outside_viewbox_not_clipped_colr_1.ttx
+++ b/tests/outside_viewbox_not_clipped_colr_1.ttx
@@ -15,7 +15,7 @@
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="g_25fd" width="100" lsb="0"/>
     <mtx name="g_25fd.0" width="100" lsb="20"/>
-    <mtx name="g_25fd.1" width="100" lsb="70"/>
+    <mtx name="g_25fd.1" width="100" lsb="20"/>
   </hmtx>
 
   <cmap>
@@ -69,24 +69,28 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="g_25fd.1" xMin="70" yMin="30" xMax="110" yMax="70">
+    <TTGlyph name="g_25fd.1" xMin="20" yMin="-60" xMax="80" yMax="0">
       <contour>
-        <pt x="110" y="50" on="1"/>
-        <pt x="110" y="56" on="0"/>
-        <pt x="105" y="65" on="0"/>
-        <pt x="96" y="70" on="0"/>
-        <pt x="90" y="70" on="1"/>
-        <pt x="84" y="70" on="0"/>
-        <pt x="75" y="65" on="0"/>
-        <pt x="70" y="56" on="0"/>
-        <pt x="70" y="50" on="1"/>
-        <pt x="70" y="44" on="0"/>
-        <pt x="75" y="35" on="0"/>
-        <pt x="84" y="30" on="0"/>
-        <pt x="90" y="30" on="1"/>
-        <pt x="96" y="30" on="0"/>
-        <pt x="105" y="35" on="0"/>
-        <pt x="110" y="44" on="0"/>
+        <pt x="80" y="-30" on="1"/>
+        <pt x="80" y="-24" on="0"/>
+        <pt x="75" y="-13" on="0"/>
+        <pt x="67" y="-5" on="0"/>
+        <pt x="56" y="0" on="0"/>
+        <pt x="50" y="0" on="1"/>
+        <pt x="44" y="0" on="0"/>
+        <pt x="33" y="-5" on="0"/>
+        <pt x="25" y="-13" on="0"/>
+        <pt x="20" y="-24" on="0"/>
+        <pt x="20" y="-30" on="1"/>
+        <pt x="20" y="-36" on="0"/>
+        <pt x="25" y="-47" on="0"/>
+        <pt x="33" y="-55" on="0"/>
+        <pt x="44" y="-60" on="0"/>
+        <pt x="50" y="-60" on="1"/>
+        <pt x="56" y="-60" on="0"/>
+        <pt x="67" y="-55" on="0"/>
+        <pt x="75" y="-47" on="0"/>
+        <pt x="80" y="-36" on="0"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -116,24 +120,29 @@
         </Paint>
         <Glyph value="g_25fd.0"/>
       </Paint>
-      <Paint index="1" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="1"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="g_25fd.1"/>
-      </Paint>
-      <Paint index="2" Format="22"><!-- PaintScaleUniformAroundCenter -->
+      <Paint index="1" Format="12"><!-- PaintTransform -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
-            <PaletteIndex value="2"/>
+            <PaletteIndex value="1"/>
             <Alpha value="1.0"/>
           </Paint>
           <Glyph value="g_25fd.1"/>
         </Paint>
-        <scale value="1.5"/>
-        <centerX value="170"/>
-        <centerY value="210"/>
+        <Transform>
+          <xx value="0.667"/>
+          <yx value="0.0"/>
+          <xy value="0.0"/>
+          <yy value="0.667"/>
+          <dx value="56.667"/>
+          <dy value="69.967"/>
+        </Transform>
+      </Paint>
+      <Paint index="2" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="2"/>
+          <Alpha value="1.0"/>
+        </Paint>
+        <Glyph value="g_25fd.1"/>
       </Paint>
     </LayerList>
     <ClipList Format="1">

--- a/tests/parentless_reused_el.ttx
+++ b/tests/parentless_reused_el.ttx
@@ -16,16 +16,16 @@
     <svgDoc endGlyphID="6" startGlyphID="4">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
-    <path d="M0,0 L64,0 L64,64 L0,64 L0,0 Z" id="g_23_20e3.0"/>
+    <path d="M600,600 L1200,600 L1200,1200 L600,1200 L600,600 Z" id="g_1f170.0"/>
   </defs>
-  <g id="glyph4" transform="matrix(9.375 0 0 9.375 37.5 -950)">
-    <use xlink:href="#g_23_20e3.0" x="32" y="32" fill="red"/>
+  <g id="glyph4" transform="translate(37.5, -950)">
+    <use xlink:href="#g_1f170.0" fill="red" x="-300" y="-300"/>
   </g>
-  <g id="glyph5" transform="matrix(9.375 0 0 9.375 37.5 -950)">
-    <use xlink:href="#g_23_20e3.0" x="64" y="64" fill="blue"/>
+  <g id="glyph5" transform="translate(37.5, -950)">
+    <use xlink:href="#g_1f170.0" fill="blue"/>
   </g>
-  <g id="glyph6" transform="matrix(9.375 0 0 9.375 37.5 -950)">
-    <use xlink:href="#g_23_20e3.0" fill="yellow"/>
+  <g id="glyph6" transform="translate(37.5, -950)">
+    <use xlink:href="#g_1f170.0" x="-600" y="-600" fill="yellow"/>
   </g>
 </svg>
 ]]>

--- a/tests/parts_test.py
+++ b/tests/parts_test.py
@@ -254,3 +254,18 @@ def test_squares_stay_squares():
     assert {p.d for p in paths} == {
         "M0,0 l3,0 l0,3 l-3,0 l0,-3 z"
     }, "The square should remain 3x3; converted to relative and starting at 0,0 they should be identical"
+
+
+def test_scaled_squares_stay_squares():
+    parts = ReusableParts(view_box=Rect(0, 0, 100, 100))
+
+    parts.add(SVG.parse(locate_test_file("square_vbox_narrow.svg")))
+    parts.add(SVG.parse(locate_test_file("square_vbox_square.svg")))
+    parts.add(SVG.parse(locate_test_file("square_vbox_narrow.svg")))
+
+    paths = only(parts.shape_sets.values())
+
+    paths = [_start_at_origin(SVGPath(d=p)).relative(inplace=True) for p in paths]
+    assert {p.d for p in paths} == {
+        "M0,0 l30,0 l0,30 l-30,0 l0,-30 z"
+    }, "The square should be 30x30"

--- a/tests/rect_colr_0.ttx
+++ b/tests/rect_colr_0.ttx
@@ -14,8 +14,8 @@
     <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="20"/>
-    <mtx name="e000.0" width="100" lsb="20"/>
-    <mtx name="e000.1" width="100" lsb="40"/>
+    <mtx name="e000.0" width="100" lsb="40"/>
+    <mtx name="e000.1" width="100" lsb="20"/>
   </hmtx>
 
   <cmap>
@@ -65,18 +65,18 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="e000.0" xMin="20" yMin="60" xMax="80" yMax="80">
+    <TTGlyph name="e000.0" xMin="40" yMin="40" xMax="100" yMax="60">
       <contour>
-        <pt x="20" y="80" on="1"/>
-        <pt x="20" y="60" on="1"/>
-        <pt x="80" y="60" on="1"/>
-        <pt x="80" y="80" on="1"/>
+        <pt x="40" y="60" on="1"/>
+        <pt x="40" y="40" on="1"/>
+        <pt x="100" y="40" on="1"/>
+        <pt x="100" y="60" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="e000.1" xMin="40" yMin="40" xMax="100" yMax="60">
-      <component glyphName="e000.0" x="20" y="-20" flags="0x4"/>
+    <TTGlyph name="e000.1" xMin="20" yMin="60" xMax="80" yMax="80">
+      <component glyphName="e000.0" x="-20" y="20" flags="0x4"/>
     </TTGlyph>
 
   </glyf>
@@ -84,8 +84,8 @@
   <COLR>
     <version value="0"/>
     <ColorGlyph name="e000">
-      <layer colorID="1" name="e000.0"/>
-      <layer colorID="0" name="e000.1"/>
+      <layer colorID="1" name="e000.1"/>
+      <layer colorID="0" name="e000.0"/>
     </ColorGlyph>
   </COLR>
 

--- a/tests/rect_colr_1.ttx
+++ b/tests/rect_colr_1.ttx
@@ -13,7 +13,7 @@
     <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
-    <mtx name="e000.0" width="100" lsb="20"/>
+    <mtx name="e000.0" width="100" lsb="40"/>
   </hmtx>
 
   <cmap>
@@ -57,12 +57,12 @@
 
     <TTGlyph name="e000"/><!-- contains no outline data -->
 
-    <TTGlyph name="e000.0" xMin="20" yMin="60" xMax="80" yMax="80">
+    <TTGlyph name="e000.0" xMin="40" yMin="40" xMax="100" yMax="60">
       <contour>
-        <pt x="20" y="80" on="1"/>
-        <pt x="20" y="60" on="1"/>
-        <pt x="80" y="60" on="1"/>
-        <pt x="80" y="80" on="1"/>
+        <pt x="40" y="60" on="1"/>
+        <pt x="40" y="40" on="1"/>
+        <pt x="100" y="40" on="1"/>
+        <pt x="100" y="60" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -85,23 +85,23 @@
     </BaseGlyphList>
     <LayerList>
       <!-- LayerCount=2 -->
-      <Paint index="0" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="0"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e000.0"/>
-      </Paint>
-      <Paint index="1" Format="14"><!-- PaintTranslate -->
+      <Paint index="0" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="0"/>
-            <Alpha value="0.8"/>
+            <Alpha value="1.0"/>
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <dx value="20"/>
-        <dy value="-20"/>
+        <dx value="-20"/>
+        <dy value="20"/>
+      </Paint>
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="0"/>
+          <Alpha value="0.8"/>
+        </Paint>
+        <Glyph value="e000.0"/>
       </Paint>
     </LayerList>
     <ClipList Format="1">

--- a/tests/rect_picosvg.ttx
+++ b/tests/rect_picosvg.ttx
@@ -61,11 +61,11 @@
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
-    <path d="M2,2 L8,2 L8,4 L2,4 L2,2 Z" id="e000.0" fill="blue"/>
+    <path d="M40,40 L100,40 L100,60 L40,60 L40,40 Z" id="e000.0" fill="blue"/>
   </defs>
-  <g id="glyph2" transform="matrix(10 0 0 10 0 -100)">
-    <use xlink:href="#e000.0"/>
-    <use xlink:href="#e000.0" x="2" y="2" opacity="0.8"/>
+  <g id="glyph2" transform="translate(0, -100)">
+    <use xlink:href="#e000.0" x="-20" y="-20"/>
+    <use xlink:href="#e000.0" opacity="0.8"/>
   </g>
 </svg>
 ]]>

--- a/tests/rects_colr_1.ttx
+++ b/tests/rects_colr_1.ttx
@@ -14,7 +14,7 @@
     <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="0"/>
-    <mtx name="e000.0" width="100" lsb="20"/>
+    <mtx name="e000.0" width="100" lsb="40"/>
     <mtx name="e001" width="100" lsb="0"/>
   </hmtx>
 
@@ -61,12 +61,12 @@
 
     <TTGlyph name="e000"/><!-- contains no outline data -->
 
-    <TTGlyph name="e000.0" xMin="20" yMin="60" xMax="80" yMax="80">
+    <TTGlyph name="e000.0" xMin="40" yMin="40" xMax="100" yMax="60">
       <contour>
-        <pt x="20" y="80" on="1"/>
-        <pt x="20" y="60" on="1"/>
-        <pt x="80" y="60" on="1"/>
-        <pt x="80" y="80" on="1"/>
+        <pt x="40" y="60" on="1"/>
+        <pt x="40" y="40" on="1"/>
+        <pt x="100" y="40" on="1"/>
+        <pt x="100" y="60" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -98,41 +98,41 @@
     </BaseGlyphList>
     <LayerList>
       <!-- LayerCount=4 -->
-      <Paint index="0" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="0"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e000.0"/>
-      </Paint>
-      <Paint index="1" Format="14"><!-- PaintTranslate -->
+      <Paint index="0" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="0"/>
-            <Alpha value="0.8"/>
+            <Alpha value="1.0"/>
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <dx value="20"/>
-        <dy value="-20"/>
+        <dx value="-20"/>
+        <dy value="20"/>
       </Paint>
-      <Paint index="2" Format="10"><!-- PaintGlyph -->
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
         <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="2"/>
-          <Alpha value="1.0"/>
+          <PaletteIndex value="0"/>
+          <Alpha value="0.8"/>
         </Paint>
         <Glyph value="e000.0"/>
       </Paint>
-      <Paint index="3" Format="14"><!-- PaintTranslate -->
+      <Paint index="2" Format="14"><!-- PaintTranslate -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
-            <PaletteIndex value="1"/>
-            <Alpha value="0.8"/>
+            <PaletteIndex value="2"/>
+            <Alpha value="1.0"/>
           </Paint>
           <Glyph value="e000.0"/>
         </Paint>
-        <dx value="20"/>
-        <dy value="-20"/>
+        <dx value="-20"/>
+        <dy value="20"/>
+      </Paint>
+      <Paint index="3" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="1"/>
+          <Alpha value="0.8"/>
+        </Paint>
+        <Glyph value="e000.0"/>
       </Paint>
     </LayerList>
     <ClipList Format="1">

--- a/tests/reorder_glyphs_test.py
+++ b/tests/reorder_glyphs_test.py
@@ -114,7 +114,7 @@ def test_reorder_actual_font():
         svgs = tuple(
             test_helper.locate_test_file(f"narrow_rects/{c}.svg") for c in "abc"
         )
-        config, glyph_inputs = test_helper.color_font_config(
+        config, parts, glyph_inputs = test_helper.color_font_config(
             {
                 "upem": 24,
                 "fea_file": fea_file,
@@ -123,7 +123,7 @@ def test_reorder_actual_font():
             tmp_dir=Path(temp_dir),
             codepoint_fn=lambda svg_file, _: (ord(svg_file.stem),),
         )
-        _, font = write_font._generate_color_font(config, glyph_inputs)
+        _, font = write_font._generate_color_font(config, parts, glyph_inputs)
 
         # Initial state
         assert _pair_pos(font) == (("a", "b", -12), ("b", "c", -16))

--- a/tests/reuse_shape_varying_fill.ttx
+++ b/tests/reuse_shape_varying_fill.ttx
@@ -61,12 +61,12 @@
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
-    <path d="M40,10 L60,10 L60,30 L40,30 L40,10 Z" id="e000.0"/>
+    <path d="M40,70 L60,70 L60,90 L40,90 L40,70 Z" id="e000.0"/>
   </defs>
   <g id="glyph2" transform="translate(0, -100)">
-    <use xlink:href="#e000.0" fill="yellow"/>
-    <use xlink:href="#e000.0" y="30" fill="red"/>
-    <use xlink:href="#e000.0" y="60" fill="blue"/>
+    <use xlink:href="#e000.0" fill="yellow" y="-60"/>
+    <use xlink:href="#e000.0" y="-30" fill="red"/>
+    <use xlink:href="#e000.0" fill="blue"/>
   </g>
 </svg>
 ]]>

--- a/tests/reused_shape_glyf.ttx
+++ b/tests/reused_shape_glyf.ttx
@@ -14,7 +14,7 @@
     <mtx name=".notdef" width="100" lsb="5"/>
     <mtx name=".space" width="100" lsb="0"/>
     <mtx name="e000" width="100" lsb="3"/>
-    <mtx name="e000.0" width="100" lsb="18"/>
+    <mtx name="e000.0" width="100" lsb="19"/>
     <mtx name="e000.1" width="100" lsb="69"/>
   </hmtx>
 
@@ -58,51 +58,51 @@
     <TTGlyph name=".space"/><!-- contains no outline data -->
 
     <TTGlyph name="e000" xMin="3" yMin="3" xMax="97" yMax="97">
-      <component glyphName="e000.0" x="0" y="0" flags="0x204"/>
       <component glyphName="e000.0" x="100" y="100" scale="-1.0" flags="0x4"/>
+      <component glyphName="e000.0" x="0" y="0" flags="0x204"/>
       <component glyphName="e000.1" x="0" y="0" flags="0x4"/>
       <component glyphName="e000.1" x="100" y="100" scale="-1.0" flags="0x4"/>
     </TTGlyph>
 
-    <TTGlyph name="e000.0" xMin="18" yMin="69" xMax="82" yMax="97">
+    <TTGlyph name="e000.0" xMin="19" yMin="3" xMax="82" yMax="31">
       <contour>
-        <pt x="50" y="69" on="1"/>
-        <pt x="56" y="69" on="0"/>
-        <pt x="66" y="73" on="0"/>
-        <pt x="74" y="79" on="0"/>
-        <pt x="78" y="86" on="0"/>
-        <pt x="81" y="90" on="0"/>
-        <pt x="81" y="90" on="1"/>
-        <pt x="81" y="92" on="0"/>
-        <pt x="82" y="94" on="0"/>
-        <pt x="81" y="96" on="1"/>
-        <pt x="79" y="97" on="0"/>
-        <pt x="77" y="97" on="1"/>
-        <pt x="76" y="96" on="0"/>
-        <pt x="75" y="95" on="1"/>
-        <pt x="75" y="93" on="0"/>
-        <pt x="71" y="88" on="0"/>
-        <pt x="65" y="83" on="0"/>
-        <pt x="56" y="80" on="0"/>
-        <pt x="50" y="80" on="1"/>
-        <pt x="44" y="80" on="0"/>
-        <pt x="35" y="83" on="0"/>
-        <pt x="29" y="88" on="0"/>
-        <pt x="25" y="93" on="0"/>
-        <pt x="25" y="94" on="1"/>
-        <pt x="24" y="96" on="0"/>
-        <pt x="21" y="97" on="0"/>
-        <pt x="20" y="96" on="1"/>
-        <pt x="19" y="96" on="0"/>
-        <pt x="19" y="96" on="1"/>
-        <pt x="18" y="95" on="0"/>
-        <pt x="19" y="91" on="0"/>
-        <pt x="19" y="90" on="1"/>
-        <pt x="19" y="90" on="0"/>
-        <pt x="22" y="86" on="0"/>
-        <pt x="26" y="79" on="0"/>
-        <pt x="33" y="73" on="0"/>
-        <pt x="43" y="69" on="0"/>
+        <pt x="51" y="31" on="1"/>
+        <pt x="44" y="31" on="0"/>
+        <pt x="34" y="27" on="0"/>
+        <pt x="27" y="21" on="0"/>
+        <pt x="22" y="14" on="0"/>
+        <pt x="20" y="10" on="0"/>
+        <pt x="20" y="10" on="1"/>
+        <pt x="19" y="8" on="0"/>
+        <pt x="19" y="6" on="0"/>
+        <pt x="20" y="4" on="1"/>
+        <pt x="21" y="3" on="0"/>
+        <pt x="23" y="3" on="1"/>
+        <pt x="24" y="4" on="0"/>
+        <pt x="25" y="5" on="1"/>
+        <pt x="26" y="7" on="0"/>
+        <pt x="29" y="12" on="0"/>
+        <pt x="35" y="17" on="0"/>
+        <pt x="44" y="20" on="0"/>
+        <pt x="51" y="20" on="1"/>
+        <pt x="57" y="20" on="0"/>
+        <pt x="65" y="17" on="0"/>
+        <pt x="71" y="12" on="0"/>
+        <pt x="75" y="7" on="0"/>
+        <pt x="76" y="6" on="1"/>
+        <pt x="76" y="4" on="0"/>
+        <pt x="79" y="3" on="0"/>
+        <pt x="81" y="4" on="1"/>
+        <pt x="81" y="4" on="0"/>
+        <pt x="81" y="4" on="1"/>
+        <pt x="82" y="5" on="0"/>
+        <pt x="82" y="9" on="0"/>
+        <pt x="81" y="10" on="1"/>
+        <pt x="81" y="10" on="0"/>
+        <pt x="79" y="14" on="0"/>
+        <pt x="74" y="21" on="0"/>
+        <pt x="67" y="27" on="0"/>
+        <pt x="57" y="31" on="0"/>
       </contour>
       <instructions/>
     </TTGlyph>

--- a/tests/reused_shape_with_gradient_colr.ttx
+++ b/tests/reused_shape_with_gradient_colr.ttx
@@ -165,7 +165,7 @@
           <xy value="0.0"/>
           <yy value="1.0"/>
           <dx value="0.0"/>
-          <dy value="-28.859"/>
+          <dy value="-28.85938"/>
         </Transform>
       </Paint>
       <Paint index="2" Format="12"><!-- PaintTransform -->
@@ -210,7 +210,7 @@
           <xy value="0.0"/>
           <yy value="1.0"/>
           <dx value="0.0"/>
-          <dy value="28.852"/>
+          <dy value="28.85156"/>
         </Transform>
       </Paint>
     </LayerList>

--- a/tests/reused_shape_with_gradient_svg.ttx
+++ b/tests/reused_shape_with_gradient_svg.ttx
@@ -61,13 +61,13 @@
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
-    <path d="M77.56,63.99 A13.56 13.56 0 1 1 50.44,63.99 A13.56 13.56 0 1 1 77.56,63.99 Z" id="e000.0"/>
+    <path d="M77.56,63.99 C77.56,71.479 71.489,77.55 64,77.55 C56.511,77.55 50.44,71.479 50.44,63.99 C50.44,56.501 56.511,50.43 64,50.43 C71.489,50.43 77.56,56.501 77.56,63.99 Z" id="e000.0"/>
     <radialGradient id="g1" cx="59.958" cy="61.112" r="13.562" gradientUnits="userSpaceOnUse">
       <stop offset="0.014" stop-color="#FFEB3B"/>
       <stop offset="0.626" stop-color="#FCCD31"/>
       <stop offset="1" stop-color="#FBC02D"/>
     </radialGradient>
-    <radialGradient id="g2" cx="59.813" cy="60.675" r="13.562" gradientUnits="userSpaceOnUse">
+    <radialGradient id="g3" cx="59.813" cy="60.675" r="13.562" gradientUnits="userSpaceOnUse">
       <stop offset="0.005" stop-color="#81C784"/>
       <stop offset="0.201" stop-color="#72BE76"/>
       <stop offset="0.719" stop-color="#50A854"/>
@@ -82,7 +82,7 @@
   </defs>
   <g id="glyph2" transform="matrix(0.781 0 0 0.781 0 -100)">
     <use xlink:href="#e000.0" fill="url(#g1)"/>
-    <use xlink:href="#e000.0" y="36.94" fill="url(#g2)"/>
+    <use xlink:href="#e000.0" y="36.94" fill="url(#g3)"/>
     <use xlink:href="#e000.0" y="-36.93" fill="url(#g4)"/>
   </g>
 </svg>

--- a/tests/smiley_cheeks_gradient_svg.ttx
+++ b/tests/smiley_cheeks_gradient_svg.ttx
@@ -61,7 +61,7 @@
     <svgDoc endGlyphID="2" startGlyphID="2">
       <![CDATA[<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
   <defs>
-    <path d="M44.75,69.83 A17.5 17.5 0 1 1 9.75,69.83 A17.5 17.5 0 1 1 44.75,69.83 Z" id="e000.0" fill="url(#g1)"/>
+    <path d="M44.75,69.83 C44.75,79.495 36.915,87.33 27.25,87.33 C17.585,87.33 9.75,79.495 9.75,69.83 C9.75,60.165 17.585,52.33 27.25,52.33 C36.915,52.33 44.75,60.165 44.75,69.83 Z" id="e000.0" fill="url(#g1)"/>
     <radialGradient id="g1" cx="27.251" cy="73.507" r="19.038" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 0.95 0 0)">
       <stop offset="0" stop-color="#ED7770" stop-opacity="0.8"/>
       <stop offset="0.9" stop-color="#ED7770" stop-opacity="0"/>

--- a/tests/svg_colr_svg_test.py
+++ b/tests/svg_colr_svg_test.py
@@ -89,16 +89,21 @@ from nanoemoji.colr_to_svg import colr_to_svg
     ],
 )
 def test_svg_to_colr_to_svg(svg_in, expected_svg_out, config_overrides):
-    config, glyph_inputs = test_helper.color_font_config(
+    config, parts, glyph_inputs = test_helper.color_font_config(
         config_overrides,
         (svg_in,),
     )
-    _, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    parts.compute_donors()
+
+    _, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
     svg_before = SVG.parse(str(test_helper.locate_test_file(svg_in)))
-    font_to_svg_scale = svg_before.view_box().h / config.upem
+
     svgs_from_font = tuple(
         colr_to_svg(
-            lambda _: svg_before.view_box(), ttfont, rounding_ndigits=3
+            lambda _: parts.view_box,
+            lambda _: svg_before.view_box(),
+            ttfont,
+            rounding_ndigits=3,
         ).values()
     )
     assert len(svgs_from_font) == 1

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -26,12 +26,15 @@ from nanoemoji import config
 from nanoemoji import features
 from nanoemoji.glyph import glyph_name
 from nanoemoji import write_font
+from nanoemoji.parts import ReusableParts
 from nanoemoji.png import PNG
 from pathlib import Path
+from picosvg.geometric_types import Rect
 from picosvg.svg import SVG
 import pytest
 import shutil
 import tempfile
+from typing import Iterable, List, Tuple
 
 
 def test_data_dir() -> Path:
@@ -72,7 +75,7 @@ def color_font_config(
     svgs,
     tmp_dir=None,
     codepoint_fn=lambda svg_file, idx: (0xE000 + idx,),
-):
+) -> Tuple[config.FontConfig, ReusableParts, List[write_font.InputGlyph]]:
     if tmp_dir is None:
         tmp_dir = Path(tempfile.gettempdir())
     svgs = tuple(locate_test_file(s) for s in svgs)
@@ -118,22 +121,41 @@ def color_font_config(
             for svg in svgs
         ]
 
-    return (
-        font_config,
-        [
-            write_font.InputGlyph(
-                svg_file,
-                bitmap_file,
-                codepoint_fn(svg_file, idx),
-                glyph_name(codepoint_fn(svg_file, idx)),
-                svg,
-                bitmap,
-            )
-            for idx, ((svg_file, svg), (bitmap_file, bitmap)) in enumerate(
-                zip(svg_inputs, bitmap_inputs)
-            )
-        ],
+    glyph_inputs = [
+        write_font.InputGlyph(
+            svg_file,
+            bitmap_file,
+            codepoint_fn(svg_file, idx),
+            glyph_name(codepoint_fn(svg_file, idx)),
+            svg,
+            bitmap,
+        )
+        for idx, ((svg_file, svg), (bitmap_file, bitmap)) in enumerate(
+            zip(svg_inputs, bitmap_inputs)
+        )
+    ]
+
+    parts = reusable_parts(font_config.upem, font_config.reuse_tolerance, glyph_inputs)
+
+    return (font_config, parts, glyph_inputs)
+
+
+def reusable_parts(
+    upem: int, reuse_tolerance: float, glyph_inputs: Iterable[write_font.InputGlyph]
+) -> ReusableParts:
+    glyph_inputs = [g for g in glyph_inputs if g.svg]
+    parts = ReusableParts(
+        reuse_tolerance=reuse_tolerance,
+        view_box=Rect(0, 0, upem, upem),
     )
+
+    for glyph_input in glyph_inputs:
+        parts.add(glyph_input.svg)
+
+    # TEMPORARY
+    print(parts.to_json())
+
+    return parts
 
 
 def reload_font(ttfont):
@@ -142,8 +164,8 @@ def reload_font(ttfont):
     return ttLib.TTFont(tmp)
 
 
-def _save_actual_ttx(expected_ttx, ttx_content):
-    tmp_file = os.path.join(tempfile.gettempdir(), expected_ttx)
+def _save_ttx_in_tmp(filename, ttx_content):
+    tmp_file = os.path.join(tempfile.gettempdir(), filename)
     with open(tmp_file, "w") as f:
         f.write(ttx_content)
     return tmp_file
@@ -179,18 +201,12 @@ def _strip_inline_bitmaps(ttx_content):
     )
 
 
-def assert_expected_ttx(
-    svgs,
-    ttfont,
-    expected_ttx,
-    include_tables=None,
-    skip_tables=("head", "hhea", "maxp", "name", "post", "OS/2"),
-):
-    actual_ttx = io.StringIO()
+def _ttx(ttfont: ttLib.TTFont, include_tables=None, skip_tables=()) -> str:
+    str_io = io.StringIO()
     # Timestamps inside files #@$@#%@#
     # force consistent Unix newlines (the expected test files use \n too)
     ttfont.saveXML(
-        actual_ttx,
+        str_io,
         newlinestr="\n",
         tables=include_tables,
         skipTables=skip_tables,
@@ -198,21 +214,37 @@ def assert_expected_ttx(
     )
 
     # Elide ttFont attributes because ttLibVersion may change
-    actual = re.sub(r'\s+ttLibVersion="[^"]+"', "", actual_ttx.getvalue())
+    ttx = re.sub(r'\s+ttLibVersion="[^"]+"', "", str_io.getvalue())
 
-    actual = _strip_inline_bitmaps(actual)
+    ttx = _strip_inline_bitmaps(ttx)
+
+    return ttx
+
+
+def assert_expected_ttx(
+    svgs,
+    ttfont,
+    expected_ttx,
+    include_tables=None,
+    skip_tables=("head", "hhea", "maxp", "name", "post", "OS/2"),
+):
+    actual = _ttx(ttfont, include_tables, skip_tables)
 
     expected_location = locate_test_file(expected_ttx)
     if os.path.isfile(expected_location):
         with open(expected_location) as f:
             expected = f.read()
     else:
-        tmp_file = _save_actual_ttx(expected_ttx, actual)
+        tmp_file = _save_ttx_in_tmp(expected_ttx, actual)
         raise FileNotFoundError(
             f"Missing expected in {expected_location}. Actual in {tmp_file}"
         )
 
     if actual != expected:
+        full_ttx_file = _save_ttx_in_tmp(
+            expected_ttx.replace(".ttx", "-complete.ttx"), _ttx(ttfont)
+        )
+
         for line in difflib.unified_diff(
             expected.splitlines(keepends=True),
             actual.splitlines(keepends=True),
@@ -221,8 +253,11 @@ def assert_expected_ttx(
         ):
             sys.stderr.write(line)
         print(f"SVGS: {svgs}")
-        tmp_file = _save_actual_ttx(expected_ttx, actual)
-        pytest.fail(f"{tmp_file} != {expected_ttx}")
+        print(f"Unabriged ttx in {full_ttx_file}")
+        tmp_file = _save_ttx_in_tmp(expected_ttx, actual)
+        pytest.fail(
+            f"{tmp_file} != {expected_location.relative_to(test_data_dir().parent)}"
+        )
 
 
 # Copied from picosvg
@@ -255,7 +290,7 @@ def svg_diff(actual_svg: SVG, expected_svg: SVG):
     drop_whitespace(expected_svg)
     print(f"A: {pretty_print(actual_svg.toetree())}")
     print(f"E: {pretty_print(expected_svg.toetree())}")
-    assert actual_svg.tostring() == expected_svg.tostring()
+    assert pretty_print(actual_svg.toetree()) == pretty_print(expected_svg.toetree())
 
 
 def run(cmd):
@@ -323,3 +358,9 @@ def bool_flag(name: str, value: bool) -> str:
         result += "no"
     result += name
     return result
+
+
+def ttx(font: ttLib.TTFont) -> str:
+    raw_out = io.BytesIO()
+    font.saveXML(raw_out)
+    return raw_out.getvalue().decode("utf-8")

--- a/tests/transformed_components_overlap.ttx
+++ b/tests/transformed_components_overlap.ttx
@@ -57,12 +57,12 @@
 
     <TTGlyph name="e000"/><!-- contains no outline data -->
 
-    <TTGlyph name="e000.0" xMin="38" yMin="69" xMax="41" yMax="72">
+    <TTGlyph name="e000.0" xMin="38" yMin="34" xMax="41" yMax="38">
       <contour>
-        <pt x="41" y="69" on="1"/>
-        <pt x="38" y="72" on="1"/>
-        <pt x="40" y="72" on="1"/>
-        <pt x="41" y="69" on="1"/>
+        <pt x="41" y="34" on="1"/>
+        <pt x="38" y="37" on="1"/>
+        <pt x="40" y="38" on="1"/>
+        <pt x="41" y="34" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -85,48 +85,7 @@
     </BaseGlyphList>
     <LayerList>
       <!-- LayerCount=4 -->
-      <Paint index="0" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="0"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="e000.0"/>
-      </Paint>
-      <Paint index="1" Format="12"><!-- PaintTransform -->
-        <Paint Format="10"><!-- PaintGlyph -->
-          <Paint Format="2"><!-- PaintSolid -->
-            <PaletteIndex value="0"/>
-            <Alpha value="1.0"/>
-          </Paint>
-          <Glyph value="e000.0"/>
-        </Paint>
-        <Transform>
-          <xx value="0.731"/>
-          <yx value="-0.717"/>
-          <xy value="-0.65"/>
-          <yy value="-0.721"/>
-          <dx value="57.273"/>
-          <dy value="151.859"/>
-        </Transform>
-      </Paint>
-      <Paint index="2" Format="12"><!-- PaintTransform -->
-        <Paint Format="10"><!-- PaintGlyph -->
-          <Paint Format="2"><!-- PaintSolid -->
-            <PaletteIndex value="0"/>
-            <Alpha value="1.0"/>
-          </Paint>
-          <Glyph value="e000.0"/>
-        </Paint>
-        <Transform>
-          <xx value="0.731"/>
-          <yx value="-0.717"/>
-          <xy value="-0.65"/>
-          <yy value="-0.721"/>
-          <dx value="57.273"/>
-          <dy value="117.219"/>
-        </Transform>
-      </Paint>
-      <Paint index="3" Format="12"><!-- PaintTransform -->
+      <Paint index="0" Format="12"><!-- PaintTransform -->
         <Paint Format="10"><!-- PaintGlyph -->
           <Paint Format="2"><!-- PaintSolid -->
             <PaletteIndex value="0"/>
@@ -140,8 +99,49 @@
           <xy value="0.0"/>
           <yy value="1.0"/>
           <dx value="0.0"/>
-          <dy value="-34.64"/>
+          <dy value="34.64"/>
         </Transform>
+      </Paint>
+      <Paint index="1" Format="12"><!-- PaintTransform -->
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="2"><!-- PaintSolid -->
+            <PaletteIndex value="0"/>
+            <Alpha value="1.0"/>
+          </Paint>
+          <Glyph value="e000.0"/>
+        </Paint>
+        <Transform>
+          <xx value="0.7314"/>
+          <yx value="-0.7173"/>
+          <xy value="-0.6503"/>
+          <yy value="-0.7214"/>
+          <dx value="34.75038"/>
+          <dy value="126.87598"/>
+        </Transform>
+      </Paint>
+      <Paint index="2" Format="12"><!-- PaintTransform -->
+        <Paint Format="10"><!-- PaintGlyph -->
+          <Paint Format="2"><!-- PaintSolid -->
+            <PaletteIndex value="0"/>
+            <Alpha value="1.0"/>
+          </Paint>
+          <Glyph value="e000.0"/>
+        </Paint>
+        <Transform>
+          <xx value="0.7314"/>
+          <yx value="-0.7173"/>
+          <xy value="-0.6503"/>
+          <yy value="-0.7214"/>
+          <dx value="34.75038"/>
+          <dy value="92.23598"/>
+        </Transform>
+      </Paint>
+      <Paint index="3" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="0"/>
+          <Alpha value="1.0"/>
+        </Paint>
+        <Glyph value="e000.0"/>
       </Paint>
     </LayerList>
     <ClipList Format="1">

--- a/tests/transformed_gradient_reuse.ttx
+++ b/tests/transformed_gradient_reuse.ttx
@@ -161,7 +161,7 @@
           <yx value="0.0"/>
           <xy value="0.0"/>
           <yy value="0.5"/>
-          <dx value="28.711"/>
+          <dx value="28.71094"/>
           <dy value="50.0"/>
         </Transform>
       </Paint>

--- a/tests/write_font_test.py
+++ b/tests/write_font_test.py
@@ -21,6 +21,7 @@ from nanoemoji import write_font
 from nanoemoji.colr import paints_of_type
 from nanoemoji.config import _DEFAULT_CONFIG
 from nanoemoji.glyphmap import GlyphMapping
+from nanoemoji.parts import ReusableParts
 from picosvg.svg_transform import Affine2D
 from ufo2ft.constants import COLR_CLIP_BOXES_KEY
 from fontTools.ttLib.tables import otTables as ot
@@ -37,10 +38,10 @@ import test_helper
 )
 @pytest.mark.parametrize("keep_glyph_names", [True, False])
 def test_keep_glyph_names(svgs, color_format, keep_glyph_names):
-    config, glyph_inputs = test_helper.color_font_config(
+    config, parts, glyph_inputs = test_helper.color_font_config(
         {"color_format": color_format, "keep_glyph_names": keep_glyph_names}, svgs
     )
-    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ufo, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
     ttfont = test_helper.reload_font(ttfont)
 
     assert len(ufo.glyphOrder) == len(ttfont.getGlyphOrder())
@@ -83,10 +84,10 @@ def test_version(color_format, version_major, version_minor, expected):
     else:
         version_minor = 0
 
-    config, glyph_inputs = test_helper.color_font_config(
+    config, parts, glyph_inputs = test_helper.color_font_config(
         config_overrides, ("rect.svg", "one-o-clock.svg")
     )
-    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ufo, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
     ttfont = test_helper.reload_font(ttfont)
 
     assert ufo.info.versionMajor == version_major
@@ -112,10 +113,10 @@ def test_vertical_metrics(ascender, descender, linegap):
         "descender": descender,
         "linegap": linegap,
     }
-    config, glyph_inputs = test_helper.color_font_config(
+    config, parts, glyph_inputs = test_helper.color_font_config(
         config_overrides, ("rect.svg", "one-o-clock.svg")
     )
-    ufo, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    ufo, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
     ttfont = test_helper.reload_font(ttfont)
 
     hhea = ttfont["hhea"]
@@ -327,8 +328,8 @@ def test_vertical_metrics(ascender, descender, linegap):
     ],
 )
 def test_write_font_binary(svgs, expected_ttx, config_overrides):
-    config, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
-    _, ttfont = write_font._generate_color_font(config, glyph_inputs)
+    config, parts, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
+    _, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
     ttfont = test_helper.reload_font(ttfont)
     # sanity check the font
     # glyf should not have identical-except-name entries except .notdef and .space
@@ -386,8 +387,8 @@ def test_write_font_binary(svgs, expected_ttx, config_overrides):
 )
 def test_ufo_color_base_glyph_bounds(svgs, config_overrides, expected_clip_boxes):
     config_overrides = {"output_file": "font.ufo", **config_overrides}
-    config, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
-    ufo, _ = write_font._generate_color_font(config, glyph_inputs)
+    config, parts, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
+    ufo, _ = write_font._generate_color_font(config, parts, glyph_inputs)
 
     base_glyph_names = [f"e{str(i).zfill(3)}" for i in range(len(svgs))]
     for base_glyph_name in base_glyph_names:
@@ -411,8 +412,10 @@ class TestCurrentColor:
     # https://github.com/googlefonts/nanoemoji/issues/380
     @staticmethod
     def generate_color_font(svgs, config_overrides):
-        config, glyph_inputs = test_helper.color_font_config(config_overrides, svgs)
-        _, ttfont = write_font._generate_color_font(config, glyph_inputs)
+        config, parts, glyph_inputs = test_helper.color_font_config(
+            config_overrides, svgs
+        )
+        _, ttfont = write_font._generate_color_font(config, parts, glyph_inputs)
         return test_helper.reload_font(ttfont)
 
     @pytest.mark.parametrize(
@@ -569,23 +572,89 @@ def test_square_varied_hmetrics():
         "square_vbox_square.svg",
         "square_vbox_wide.svg",
     )
-    config, glyph_inputs = test_helper.color_font_config({"width": 0}, svgs)
-    _, font = write_font._generate_color_font(config, glyph_inputs)
+    config, parts, glyph_inputs = test_helper.color_font_config({"width": 0}, svgs)
+    parts.compute_donors()
+
+    _, font = write_font._generate_color_font(config, parts, glyph_inputs)
 
     colr = font["COLR"]
 
     glyph_names = {r.BaseGlyph for r in colr.table.BaseGlyphList.BaseGlyphPaintRecord}
     assert (
         len(glyph_names) == 3
-    ), f"Should have 3 color glyphs, got {names_of_colr_glyphs}"
+    ), f"Should have 3 color glyphs, got {names_of_colr_glyphs}\n{test_helper.ttx(font)}"
 
     glyphs = {p.Glyph for p in paints_of_type(font, ot.PaintFormat.PaintGlyph)}
     assert (
         len(glyphs) == 1
-    ), f"Should only be one glyph referenced from COLR, got {glyphs}"
+    ), f"Should only be one glyph referenced from COLR, got {glyphs}\n{test_helper.ttx(font)}"
 
     glyph_widths = sorted(font["hmtx"][gn][0] for gn in glyph_names)
     for i in range(len(glyph_widths) - 1):
         assert (
             glyph_widths[i] * 2 == glyph_widths[i + 1]
-        ), f"n+1 should double, fails at {i}; {glyph_widths}"
+        ), f"n+1 should double, fails at {i}; {glyph_widths}\n{test_helper.ttx(font)}"
+
+
+# scaling was at one point causing lookup in part file to fail
+# TODO this doesn't reproduce the problem :(
+def test_inconsistent_viewbox():
+    # rect 1000 will cause part merge to scale
+    svgs = (
+        "circle.svg",
+        "rect_1000.svg",
+    )
+
+    config, parts, glyph_inputs = test_helper.color_font_config(
+        {
+            "upem": 1024,
+            "ascender": 950,
+            "descender": -250,
+            "width": 1275,
+        },
+        svgs,
+    )
+    parts.compute_donors()
+
+    # just compiling without error will suffice :)
+    write_font._generate_color_font(config, parts, glyph_inputs)
+
+
+def test_reuse_with_inconsistent_viewbox():
+    svgs = (
+        "rect.svg",
+        "rect_10x.svg",
+    )
+    config, parts, glyph_inputs = test_helper.color_font_config({}, svgs)
+    parts.compute_donors()
+
+    _, font = write_font._generate_color_font(config, parts, glyph_inputs)
+
+    # There should be only one glyph referenced by COLR
+    glyphs = {p.Glyph for p in paints_of_type(font, ot.PaintFormat.PaintGlyph)}
+    assert len(glyphs) == 1, str(glyphs)
+
+
+# Reduced version of real problem observed with the demo fonts repo
+# where an affine with massive coordinates was produced (dx = 54033)
+def test_reuse_with_real_inconsistent_viewbox():
+    svgs = (
+        "rect_10.svg",
+        "rect_1000.svg",
+    )
+    config, parts, glyph_inputs = test_helper.color_font_config(
+        {
+            "upem": 1024,
+            "ascender": 950,
+            "descender": -250,
+            "width": 1275,
+        },
+        svgs,
+    )
+    parts.compute_donors()
+
+    _, font = write_font._generate_color_font(config, parts, glyph_inputs)
+
+    # There should be only one glyph referenced by COLR
+    glyphs = {p.Glyph for p in paints_of_type(font, ot.PaintFormat.PaintGlyph)}
+    assert len(glyphs) == 1, str(glyphs)


### PR DESCRIPTION
Fixes #415. Fixes #313. Makes identifying and troubleshooting reuse failure far far easier as things in build/parts-merged.json with donor null after a build are the ones that failed affine_between, you can look to see if you agree with how things grouped, etc.

TODO list:

- [x] Merge #417 to mitigate excessive diff complexity :)
- [ ] Add an assert that the y-scale from combined parts => font space is 1 per https://github.com/googlefonts/nanoemoji/pull/417#pullrequestreview-1002620346
- [ ] Shapes seem good but gradients broken, see things like the svg for tests/clocks_picosvg.ttx or tests/smiley_cheeks_gradient_svg.ttx
- [ ] Add tests specifically targeting svg _glyph_groups
  * groups if an identical path appears in two color glyphs
  * groups if a path reused by transform appears
  * otherwise ... not
- [x] Rename ReuseInstruction to something like ReuseResult; XInstruction makes everyone think hints
- [ ] Check we can still build and render Noto Emoji & all demo fonts in color-fonts
  - [x] `nanoemoji ../svg/emoji_u1f6d2.svg` from https://github.com/googlefonts/noto-emoji/tree/colrv1/colrv1 fails
  - [ ] check clock emoji; they are getting significantly different ttx 
- [ ] Check that fonts didn't get bigger, ideally they got slightly smaller
  - [x] Noto Emoji colrv1, no flags is slightly smaller (2932768 => 2858124 bytes, -74644), probably because we are able to prefer to create smaller from larger instead of taking shapes in the order of encounter
  - [x] https://github.com/googlefonts/picosvg/pull/272 adds a further -34856
- [ ] Confirm https://github.com/rsheeter/color_aboard still works