### PR TITLE
take first in multi-palette CPAL; convert 0xFFFF palette index to SVG fill="currentColor"

### DIFF
--- a/src/nanoemoji/colr_to_svg.py
+++ b/src/nanoemoji/colr_to_svg.py
@@ -108,7 +108,7 @@ def _first_cpal_palette(ttfont: ttLib.TTFont) -> List[C_P_A_L_.Color]:
 
 def _color(ttfont: ttLib.TTFont, palette_index, alpha=1.0) -> colors.Color:
     if palette_index == _FOREGROUND_COLOR_INDEX:
-        return colors.Color.fromstring("black")  # as good a guess as any
+        return colors.Color.fromstring("currentColor", alpha=alpha)
 
     # Only take the first palette for now:
     # https://github.com/googlefonts/nanoemoji/issues/421

--- a/src/nanoemoji/colr_to_svg.py
+++ b/src/nanoemoji/colr_to_svg.py
@@ -399,7 +399,13 @@ def colr_to_svg(
     rounding_ndigits: Optional[int] = None,
 ) -> Dict[str, SVG]:
     """For testing only, don't use for real!"""
-    assert len(ttfont["CPAL"].palettes) == 1, "We assume one palette"
+    num_palettes = len(ttfont["CPAL"].palettes)
+    if num_palettes > 1:
+        logging.warning(
+            "Multiple CPAL palettes are not supported! Only using the first"
+        )
+    elif num_palettes < 1:
+        raise ValueError("No CPAL palettes found, at least one required")
 
     colr_version = ttfont["COLR"].version
     if colr_version == 0:


### PR DESCRIPTION
in an attempt to fix https://github.com/googlefonts/nanoemoji/issues/421 and allow ReekKufiInk be converted from COLRv1 to OT-SVG...