### PR TITLE
fix maximum_color'ing 0-width glyphs

### DIFF
--- a/src/nanoemoji/colr_to_svg.py
+++ b/src/nanoemoji/colr_to_svg.py
@@ -327,15 +327,9 @@ def glyph_region(ttfont: ttLib.TTFont, glyph_name: str) -> Rect:
 def _view_box_and_transform(
     ttfont: ttLib.TTFont, view_box_callback: ViewboxCallback, glyph_name: str
 ) -> Tuple[Rect, Affine2D]:
-
     view_box = view_box_callback(glyph_name)
-    assert view_box.w > 0, f"0-width viewBox for {glyph_name}?!"
-
     region = glyph_region(ttfont, glyph_name)
-    assert region.w > 0, f"0-width region for {glyph_name}?!"
-
     font_to_vbox = map_font_space_to_viewbox(view_box, region)
-
     return (view_box, font_to_vbox)
 
 

--- a/src/nanoemoji/colr_to_svg.py
+++ b/src/nanoemoji/colr_to_svg.py
@@ -312,10 +312,6 @@ def glyph_region(ttfont: ttLib.TTFont, glyph_name: str) -> Rect:
 
     map_font_space_to_viewbox handles font +y goes up => svg +y goes down."""
     width = ttfont["hmtx"][glyph_name][0]
-    if width == 0:
-        glyph = ttfont["glyf"][glyph_name]
-        if hasattr(glyph, "xMax"):  # empty glyphs have no bbox attributes
-            width = glyph.xMax
     return Rect(
         0,
         -ttfont["OS/2"].sTypoAscender,

--- a/src/nanoemoji/colr_to_svg.py
+++ b/src/nanoemoji/colr_to_svg.py
@@ -313,7 +313,9 @@ def glyph_region(ttfont: ttLib.TTFont, glyph_name: str) -> Rect:
     map_font_space_to_viewbox handles font +y goes up => svg +y goes down."""
     width = ttfont["hmtx"][glyph_name][0]
     if width == 0:
-        width = ttfont["glyf"][glyph_name].xMax
+        glyph = ttfont["glyf"][glyph_name]
+        if hasattr(glyph, "xMax"):  # empty glyphs have no bbox attributes
+            width = glyph.xMax
     return Rect(
         0,
         -ttfont["OS/2"].sTypoAscender,

--- a/src/nanoemoji/generate_svgs_from_colr.py
+++ b/src/nanoemoji/generate_svgs_from_colr.py
@@ -37,9 +37,7 @@ flags.DEFINE_string(
 
 def _view_box(font: ttLib.TTFont, glyph_name: str) -> Rect:
     # we want a viewbox that results in no scaling when translating from font-space
-    region = glyph_region(font, glyph_name)
-    assert region.w > 0, f"0-width region for {glyph_name}"
-    return region
+    return glyph_region(font, glyph_name)
 
 
 def main(argv):

--- a/tests/emoji_u0301.svg
+++ b/tests/emoji_u0301.svg
@@ -1,3 +1,0 @@
-<svg viewBox="0 0 0 10" xmlns="http://www.w3.org/2000/svg">
-  <rect x="2" y="2" width="1" height="2" fill="red" />
-</svg>

--- a/tests/emoji_u0301.svg
+++ b/tests/emoji_u0301.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 0 10" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="1" height="2" fill="red" />
+</svg>

--- a/tests/maximum_color_test.py
+++ b/tests/maximum_color_test.py
@@ -121,9 +121,9 @@ def test_zero_advance_width_colrv1_to_svg():
             # don't clip to viewBox else zero-width glyph disappears
             "--noclip_to_viewbox",
             locate_test_file("emoji_u42.svg"),
-            # this one has viewBox="0 0 0 10", i.e. zero width, like
+            # this one has viewBox="0 0 0 1200", i.e. zero width, like
             # combining marks usually are (e.g. 'acutecomb')
-            locate_test_file("emoji_u0301.svg"),
+            locate_test_file("u0301.svg"),
         )
     )
 

--- a/tests/nanoemoji_test.py
+++ b/tests/nanoemoji_test.py
@@ -408,7 +408,7 @@ def test_glyph_with_zero_advance_width(color_format, tmp_path):
         svg = font["SVG "]
         assert len(svg.docList) == 1
         gid = font.getGlyphID(gname)
-        assert svg.docList[0][1:] == [gid, gid]  # [start, end]
+        assert svg.docList[0][1:] == (gid, gid)  # (start, end)
     if "CBDT" in font:
         cbdt = font["CBDT"]
         assert len(cbdt.strikeData) == 1


### PR DESCRIPTION
trying to reproduce issues converting COLRv1 font to OT-SVG when the former contains glyphs with 0 advance width (https://github.com/googlefonts/nanoemoji/issues/421)