### PR TITLE
[SVG] ensure colored .notdef stays as gid0 when reordering svg glyphs for reuse

### DIFF
--- a/src/nanoemoji/disjoint_set.py
+++ b/src/nanoemoji/disjoint_set.py
@@ -46,6 +46,6 @@ class DisjointSet(Generic[T]):
             sets[self.find(e)].add(e)
         return frozenset(frozenset(s) for s in sets.values())
 
-    def sorted(self) -> Tuple[Tuple[T, ...]]:
+    def sorted(self) -> Tuple[Tuple[T, ...], ...]:
         """Sorted tuple of sorted tuples edition of sets()."""
         return tuple(sorted(tuple(sorted(s)) for s in self.sets()))

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -127,11 +127,11 @@ def _glyph_groups(
 
     # If the color glyphs contain '.notdef', we want to keep it the first glyph, so
     # we must avoid grouping it with the rest, as they get reshuffled later on.
-    has_color_notdef = False
+    initial_glyphs = ()
     for color_glyph in color_glyphs:
         if color_glyph.ufo_glyph_name == ".notdef":
             assert color_glyph.glyph_id == 0
-            has_color_notdef = True
+            initial_glyphs = ((".notdef",),)
             break
 
     # ensure glyphs sharing shapes are in the same doc
@@ -165,12 +165,7 @@ def _glyph_groups(
 
                 nth_paint_glyph += 1
 
-    sorted_groups = reuse_groups.sorted()
-
-    if has_color_notdef:
-        return ((".notdef",),) + sorted_groups
-    else:
-        return sorted_groups
+    return initial_glyphs + reuse_groups.sorted()
 
 
 def _ntos(n: float) -> str:

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -122,7 +122,7 @@ def _color_glyph_name(glyph_name: str) -> str:
 
 def _glyph_groups(
     config: FontConfig, color_glyphs: Sequence[ColorGlyph], reuse_cache: ReuseCache
-) -> Tuple[Tuple[str, ...]]:
+) -> Tuple[Tuple[str, ...], ...]:
     """Find glyphs that need to be kept together by union find."""
 
     # If the color glyphs contain '.notdef', we want to keep it the first glyph, so
@@ -134,7 +134,8 @@ def _glyph_groups(
             has_color_notdef = True
             break
 
-    reuse_groups = DisjointSet()  # ensure glyphs sharing shapes are in the same doc
+    # ensure glyphs sharing shapes are in the same doc
+    reuse_groups = DisjointSet[str]()
     for color_glyph in color_glyphs:
         if color_glyph.ufo_glyph_name != ".notdef":
             reuse_groups.make_set(color_glyph.ufo_glyph_name)

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -579,7 +579,6 @@ def _ensure_ttfont_fully_decompiled(ttfont: ttLib.TTFont):
 
 def _ensure_groups_grouped_in_glyph_order(
     color_glyphs: MutableMapping[str, ColorGlyph],
-    color_glyph_order: Sequence[str],
     ttfont: ttLib.TTFont,
     reuse_groups: Tuple[Tuple[str, ...]],
 ):
@@ -655,11 +654,8 @@ def _picosvg_docs(
         config.reuse_tolerance, GlyphReuseCache(config.reuse_tolerance)
     )
     reuse_groups = _glyph_groups(config, color_glyphs, reuse_cache)
-    color_glyph_order = [c.ufo_glyph_name for c in color_glyphs]
     color_glyphs = {c.ufo_glyph_name: c for c in color_glyphs}
-    _ensure_groups_grouped_in_glyph_order(
-        color_glyphs, color_glyph_order, ttfont, reuse_groups
-    )
+    _ensure_groups_grouped_in_glyph_order(color_glyphs, ttfont, reuse_groups)
 
     doc_list = []
     for group in reuse_groups:

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -725,6 +725,7 @@ def _generate_color_font(config: FontConfig, inputs: Iterable[InputGlyph]):
 
     color_glyphs = []
     glyph_order = list(ufo.glyphOrder)
+    assert glyph_order[0] == ".notdef"
     for glyph_input in inputs:
         if glyph_input.glyph_name in glyph_order:
             gid = glyph_order.index(glyph_input.glyph_name)

--- a/tests/colored_notdef.svg
+++ b/tests/colored_notdef.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -860 1000 1000">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="0" y2="-900" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop offset="0" stop-color="#C90900"/>
+      <stop offset="1" stop-color="gold"/>
+    </linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="-900" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop offset="0" stop-color="gold"/>
+      <stop offset="1" stop-color="#C90900"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#g1)" d="M864,40 Q883,40 891.5,31.5 Q900,23 900,4 L900,-724 Q900,-743 891.5,-751.5 Q883,-760 864,-760 L136,-760 Q117,-760 108.5,-751.5 Q100,-743 100,-724 L100,4 Q100,23 108.5,31.5 Q117,40 136,40 Z M850,-10 L150,-10 L150,-710 L850,-710 L850,-710 Z"/>
+  <path fill="url(#g2)" d="M870,10 L870,-730 L130,-730 L130,10 Z M120,20 L120,-740 L880,-740 L880,20 Z"/>
+</svg>

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -72,6 +72,7 @@ def color_font_config(
     svgs,
     tmp_dir=None,
     codepoint_fn=lambda svg_file, idx: (0xE000 + idx,),
+    glyphname_fn=None,
 ):
     if tmp_dir is None:
         tmp_dir = Path(tempfile.gettempdir())
@@ -118,6 +119,11 @@ def color_font_config(
             for svg in svgs
         ]
 
+    if glyphname_fn is None:
+
+        def glyphname_fn(svg_file, idx):
+            return glyph_name(codepoint_fn(svg_file, idx))
+
     return (
         font_config,
         [
@@ -125,7 +131,7 @@ def color_font_config(
                 svg_file,
                 bitmap_file,
                 codepoint_fn(svg_file, idx),
-                glyph_name(codepoint_fn(svg_file, idx)),
+                glyphname_fn(svg_file, idx),
                 svg,
                 bitmap,
             )


### PR DESCRIPTION
Fixes #427 