### PR TITLE
maximum_color: skip svg table generation for colr v0 fonts

### DIFF
--- a/src/nanoemoji/maximum_color.py
+++ b/src/nanoemoji/maximum_color.py
@@ -440,10 +440,16 @@ def _run(argv):
         input_file.resolve() != (build_dir() / final_output).resolve()
     ), "In == Out is bad"
 
+    color_table = _vector_color_table(font)
+    if color_table == "COLR" and font["COLR"].version == 0:
+        logging.info(
+            f"Font has colr v0 table which is widely supported in most "
+            "browsers so the font does not require an SVG color table."
+            )
+        return
+
     build_file = build_dir() / "build.ninja"
     build_dir().mkdir(parents=True, exist_ok=True)
-
-    color_table = _vector_color_table(font)
 
     if gen_ninja():
         logging.info(f"Generating {build_file.relative_to(build_dir())}")


### PR DESCRIPTION
For fonts released on Google Fonts, we don't want to run maximum_color on colr v0 fonts since they're well supported in modern browsers.

Feel free to close this if you feel it's too restrictive. I can always move this functionality to our own gftools builder so it will only work on fonts destined for GF.