### PR TITLE
add --colr_version flag to maximum_color

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        # typed_ast (used by pytype) has a problem when run under 3.9.8, pin to 3.9.7
-        # until resolved: https://github.com/python/typed_ast/issues/169
-        python-version: "3.9.7"
+        python-version: "3.9"
     - name: Install tox
       run: pip install tox
     - name: Run style and typing checks

--- a/src/nanoemoji/glue_together.py
+++ b/src/nanoemoji/glue_together.py
@@ -46,9 +46,21 @@ class CbdtGlyphInfo(NamedTuple):
 
 def _copy_colr(target: ttLib.TTFont, donor: ttLib.TTFont):
     # Copy all glyphs used by COLR over
-    glyphs_to_copy = sorted(
-        {p.Glyph for p in paints_of_type(donor, ot.PaintFormat.PaintGlyph)}
-    )
+    colr_version = donor["COLR"].version
+    if colr_version == 1:
+        glyphs_to_copy = sorted(
+            {p.Glyph for p in paints_of_type(donor, ot.PaintFormat.PaintGlyph)}
+        )
+    elif colr_version == 0:
+        glyphs_to_copy = sorted(
+            {
+                rec.name
+                for layers in donor["COLR"].ColorLayers.values()
+                for rec in layers
+            }
+        )
+    else:
+        raise NotImplementedError(colr_version)
 
     # We avoid using the glyf table's `__setitem__` for it appends to the TTFont's
     # glyphOrder list without also invalidating the {glyphNames:glyphID} cache,

--- a/tests/maximum_color_test.py
+++ b/tests/maximum_color_test.py
@@ -98,6 +98,24 @@ def test_build_maximum_font(color_format, expected_new_tables, bitmaps, input_fi
     assert set(maximum_font.keys()) - set(initial_font.keys()) == expected_new_tables
 
 
+@pytest.mark.parametrize("colr_version", [None, 0, 1])
+def test_build_colrv0_from_svg(colr_version):
+    initial_font_file = _build_initial_font("picosvg")
+
+    additional_flags = ()
+    if colr_version is not None:
+        additional_flags = ("--colr_version", str(colr_version))
+
+    maxmium_font_file = _maximize_color(initial_font_file, additional_flags)
+
+    initial_font = ttLib.TTFont(initial_font_file)
+    maximum_font = ttLib.TTFont(maxmium_font_file)
+    assert set(maximum_font.keys()) - set(initial_font.keys()) == {"COLR", "CPAL"}
+
+    expected_version = 1 if colr_version is None else colr_version
+    assert maximum_font["COLR"].version == expected_version
+
+
 @pytest.mark.parametrize("keep_names", [True, False])
 def test_keep_glyph_names(keep_names):
     initial_font_file = _build_initial_font("glyf_colr_1")


### PR DESCRIPTION
To support generating COLRv0 from OT-SVG font.
Fixes https://github.com/googlefonts/nanoemoji/issues/435

(Note that by default we continue to generate COLRv1 from OT-SVG)