### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ jobs:
     strategy:
       matrix:
         config:
-          - {platform: ubuntu-latest, python-version: 3.7}
-          - {platform: ubuntu-latest, python-version: 3.8}
-          - {platform: ubuntu-latest, python-version: 3.9}
-          - {platform: windows-latest, python-version: 3.9}
+          - {platform: ubuntu-latest, python-version: "3.8"}
+          - {platform: ubuntu-latest, python-version: "3.9"}
+          - {platform: ubuntu-latest, python-version: "3.10"}
+          - {platform: ubuntu-latest, python-version: "3.11"}
+          - {platform: windows-latest, python-version: "3.11"}
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ nanoemoji --helpfull
 nanoemoji --color_format glyf_colr_1 $(find ../noto-emoji/svg -name 'emoji_u270d*.svg')
 ```
 
-Requires Python 3.7 or greater.
+Requires Python 3.8 or greater.
 
 ## Color table support
 

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ setup(
         "pngquant-cli>=2.17.0.post5",
     ],
     extras_require=extras_require,
-    # this is so we can use the built-in dataclasses module
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 
     # this is for type checker to use our inline type hints:
     # https://www.python.org/dev/peps/pep-0561/#id18

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "picosvg>=0.22.1",
         "pillow>=7.2.0",
         "regex>=2020.4.4",
-        "tomlkit",
+        "toml>=0.10.1",
         "ufo2ft[cffsubr]>=2.24.0",
         "ufoLib2>=0.6.2",
         "resvg-cli>=0.22.0.post3",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 ;   $ export TOXENV=py39
 ;   $ tox
 ;     # If present use $TOXENV environment variable
-envlist = lint, py3{7,8,9}
+envlist = lint, py3{8,9,10,11}
 
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error


### PR DESCRIPTION
it reached end of life, and picosvg also requires >= python 3.8 so we must move forward as well.
