### PR TITLE
Update ci.yml based on ufo2ft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
     - name: Install tox
@@ -31,10 +31,10 @@ jobs:
           - {platform: ubuntu-latest, python-version: "3.11"}
           - {platform: windows-latest, python-version: "3.11"}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.config.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -51,13 +51,17 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
+    # This is required to create a release using Github integration token
+    # https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         # setuptools_scm requires the git clone to not be 'shallow'
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install dependencies


### PR DESCRIPTION
It went stale. Make the same updates as https://github.com/googlefonts/picosvg/pull/325.

Should fix release, currently fails, ex https://github.com/googlefonts/picosvg/actions/runs/14714290114