### PR TITLE
[test_helper] rename helper function to circumvent pytest's overly greedy test discovery

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -15,7 +15,7 @@
 from nanoemoji import config
 from pathlib import Path
 import pytest
-from test_helper import test_data_dir, locate_test_file
+from test_helper import TEST_DATA_DIR, locate_test_file
 import shutil
 import tempfile
 from typing import Iterable
@@ -51,13 +51,13 @@ def test_read_write_config(config_file):
     [
         # relative single file
         (
-            test_data_dir(),
+            TEST_DATA_DIR,
             "minimal_static/svg/61.svg",
             {locate_test_file("minimal_static/svg/61.svg")},
         ),
         # relative pattern
         (
-            test_data_dir(),
+            TEST_DATA_DIR,
             "linear_gradient_transform*.svg",
             {
                 locate_test_file("linear_gradient_transform.svg"),
@@ -67,14 +67,14 @@ def test_read_write_config(config_file):
         ),
         # absolute single file
         (
-            test_data_dir(),
+            TEST_DATA_DIR,
             locate_test_file("minimal_static/svg/61.svg").resolve(),
             {locate_test_file("minimal_static/svg/61.svg")},
         ),
         # absolute pattern
         (
             None,
-            test_data_dir().resolve() / "**" / "linear_gradient_transform_*.svg",
+            TEST_DATA_DIR.resolve() / "**" / "linear_gradient_transform_*.svg",
             {
                 locate_test_file("linear_gradient_transform_2.svg"),
                 locate_test_file("linear_gradient_transform_3.svg"),

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -34,12 +34,11 @@ import shutil
 import tempfile
 
 
-def test_data_dir() -> Path:
-    return Path(__file__).parent
+TEST_DATA_DIR = Path(__file__).parent
 
 
 def locate_test_file(filename) -> Path:
-    return test_data_dir() / filename
+    return TEST_DATA_DIR / filename
 
 
 def parse_svg(filename, locate=False, topicosvg=True):


### PR DESCRIPTION
Meant to fix https://github.com/googlefonts/nanoemoji/pull/480

Something must have changed in pytest 8.4.0 which makes the test collection/discovery treat this little test helper function named 'test_data_dir' as a test function (pytest errors because it expects some asserts), which it is cleary not.

We make it a constant (Path objects are immutable) to workaround this