### PR TITLE
Some hacks for CFF support (and other things) in maximum_color

### DIFF
--- a/src/nanoemoji/extract_svgs_from_otsvg.py
+++ b/src/nanoemoji/extract_svgs_from_otsvg.py
@@ -42,6 +42,8 @@ flags.DEFINE_string(
     "ERROR, or FATAL.",
 )
 
+flags.DEFINE_integer("ascender_override", 0xFFFFFFFF, "Override ascender value for translate.")
+
 
 def main(argv):
     logging.set_verbosity(FLAGS.log_level)
@@ -55,6 +57,9 @@ def main(argv):
     upem = font["head"].unitsPerEm
     ascender = font["OS/2"].sTypoAscender
     descender = font["OS/2"].sTypoDescender
+    trans_ascender = ascender
+    if FLAGS.ascender_override != 0xFFFFFFFF:
+        trans_ascender = FLAGS.ascender_override
     metrics = font["hmtx"].metrics
     logging.debug("Writing svgs from %s to %s", font_file, out_dir)
     logging.debug("upem %d ascender %d descender %d", upem, ascender, descender)
@@ -66,7 +71,7 @@ def main(argv):
     for gid, svg in svg_glyphs(font):
         svg_defs = etree.Element("defs")
         svg_g = etree.Element("g")
-        svg_g.attrib["transform"] = f"translate(0, {ascender})"
+        svg_g.attrib["transform"] = f"translate(0, {trans_ascender})"
 
         for el in svg.svg_root:
             if strip_ns(el.tag) == "defs":

--- a/src/nanoemoji/write_config_for_mergeable.py
+++ b/src/nanoemoji/write_config_for_mergeable.py
@@ -32,12 +32,13 @@ def main(argv):
     upem = font["head"].unitsPerEm
     ascender = font["OS/2"].sTypoAscender
     descender = font["OS/2"].sTypoDescender
+    suffix = 'otf' if FLAGS.color_format.startswith('cff') else 'ttf'
 
     with open(config_file, "w") as f:
         f.write(
             textwrap.dedent(
                 f"""
-            output_file = "COLR.ttf"
+            output_file = "COLR.{suffix}"
             color_format = "{FLAGS.color_format}"
             upem = {upem}
             width = 0  # from input width

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -195,10 +195,10 @@ def _ufo(config: FontConfig) -> ufoLib2.Font:
 
     # Must have .notdef and Win 10 Chrome likes a blank gid1 so make gid1 space
     ufo.newGlyph(".notdef")
-    space = ufo.newGlyph(".space")
+    space = ufo.newGlyph("space")
     space.unicodes = [0x0020]
     space.width = config.width
-    ufo.glyphOrder = [".notdef", ".space"]
+    ufo.glyphOrder = [".notdef", "space"]
 
     # Always the .notdef outline, even for things like a pure SVG font
     # This decreases the odds of triggering https://github.com/khaledhosny/ots/issues/52
@@ -232,7 +232,8 @@ def _make_ttfont(
         if config.color_format.startswith("cff2_"):
             cff_version = 2
         ttfont = ufo2ft.compileOTF(
-            ufo, cffVersion=cff_version, overlapsBackend="pathops"
+            ufo, cffVersion=cff_version, overlapsBackend="pathops",
+            optimizeCFF=False
         )
 
     if not ttfont:


### PR DESCRIPTION
This isn't a real PR. I wound up needing to convert a CFF-based SVG font to COLRv1 and these were the various hacks I used to build it with nanoemoji. I'm just sharing this in case it may come in handy. Some of the changes would work as-is but some just overwrite the glyf path (especially in glue_together) because I was just trying to get something done. 

I don't know what's going on with the ascender_override stuff. The extractor was writing in 750 where what was needed was -250. I don't know if that's a CFF-specific thing, something to do with the encoding of the SVGs in the font, or something else.

I also had to deal with some out of bounds gradients. Could be a problem with the source data, not sure. 

The underlying problem here, and most likely the reason CFF wasn't supported all the way through in the first place, is the brittleness and decentralization of the fontTools cffLib structures. This is in stark contrast to how the same structures are represented in `ttx` XML. It would be nice if there were an edit-oriented model one could switch between, possibly based on the XML hierarchy. 