### PR TITLE
Fix colr2svg tool

### DIFF
--- a/tools/colr2svg.py
+++ b/tools/colr2svg.py
@@ -37,12 +37,14 @@ parser.add_argument(
 options = parser.parse_args(sys.argv[1:])
 
 font = TTFont(options.fontfile)
-viewbox = Rect(0, 0, options.viewbox_size, options.viewbox_size)
 
 os.makedirs(options.destdir, exist_ok=True)
 
+def viewbox_callback(_: str) -> Rect:
+    return Rect(0, 0, options.viewbox_size, options.viewbox_size)
+
 for glyph_name, svg in colr_to_svg(
-    viewbox, font, rounding_ndigits=options.rounding_ndigits
+    viewbox_callback, font, rounding_ndigits=options.rounding_ndigits
 ).items():
     output_file = os.path.join(options.destdir, f"{glyph_name}.svg")
     with open(output_file, "w") as f:


### PR DESCRIPTION
# Issue

`colr_to_svg` expects a ViewboxCallback which is a `# f(glyph_name) -> Rect`

- `colr_to_svg` defined at https://github.com/googlefonts/nanoemoji/blob/main/src/nanoemoji/colr_to_svg.py#L411
- `ViewboxCallback` defined at https://github.com/googlefonts/nanoemoji/blob/main/src/nanoemoji/colr_to_svg.py#L60

# Fix

Wrap `Rect` in a function

# Demo

```
tools/colr2svg.py ~/src/sleipnir/resources/testdata/nabla.ttf  ./

...some svg filenames....
```

![A](https://github.com/user-attachments/assets/1b76a156-6b68-47a3-b01e-0badcc219438)

