### PR TITLE
Fix ZeroDivisionError in _compute_donor when reuse_tolerance=-1

### DIFF
--- a/src/nanoemoji/parts.py
+++ b/src/nanoemoji/parts.py
@@ -185,6 +185,13 @@ class ReusableParts:
         )
         svg_paths = [SVGPath(d=s) for s in svg_paths]
 
+        if self.reuse_tolerance == -1:
+            # No reuse across different shapes; all paths in the set are identical
+            # strings (since normalize() returns raw paths when tolerance is -1),
+            # so any path is a valid donor.
+            self._donor_cache[norm] = Shape(svg_paths[0].d)
+            return
+
         for svg_path in svg_paths:
             if all(
                 affine_between(svg_path, svg_path2, self.reuse_tolerance) is not None


### PR DESCRIPTION
Fixes and  supersedes https://github.com/googlefonts/picosvg/pull/334

When `reuse_tolerance=-1`, every other call site in nanoemoji already guards against passing it to picosvg ([`normalize()`](https://github.com/googlefonts/nanoemoji/blob/4444aa88acdbef55ff13e73255540472e324832f/src/nanoemoji/parts.py#L121), [`try_reuse()`](https://github.com/googlefonts/nanoemoji/blob/4444aa88acdbef55ff13e73255540472e324832f/src/nanoemoji/parts.py#L216), [`glyph_reuse.py`](https://github.com/googlefonts/nanoemoji/blob/4444aa88acdbef55ff13e73255540472e324832f/src/nanoemoji/glyph_reuse.py#L57)). But [`_compute_donor`](https://github.com/googlefonts/nanoemoji/blob/4444aa88acdbef55ff13e73255540472e324832f/src/nanoemoji/parts.py#L190) passed it through to `affine_between`, which crashes because `almost_equals` treats every pair as unequal when tolerance < 0.

Since `ReusableParts.normalize()` returns raw path strings when tolerance is -1, all paths in a shape set are identical (they're grouped by the raw string), so `_compute_donor` can just pick the first one without calling `affine_between`.

