### PR TITLE
Bump lint tox env from Python 3.9 to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,16 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python 3.12
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.12"
     - name: Install tox
@@ -31,10 +34,10 @@ jobs:
           - {platform: ubuntu-latest, python-version: "3.11"}
           - {platform: windows-latest, python-version: "3.11"}
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python ${{ matrix.config.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -56,12 +59,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # setuptools_scm requires the git clone to not be 'shallow'
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.x"
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Set up Python 3.12
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
@@ -35,6 +37,8 @@ jobs:
           - {platform: windows-latest, python-version: "3.11"}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.config.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -63,6 +67,7 @@ jobs:
       with:
         # setuptools_scm requires the git clone to not be 'shallow'
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
@@ -95,13 +100,8 @@ jobs:
         fi
     - name: Create GitHub release
       id: create_release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
-      env:
-        # This token is provided by Actions, you do not need to create your own token
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
         body_path: "${{ runner.temp }}/release_notes.md"
         draft: false
         prerelease: ${{ env.IS_PRERELEASE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.12"
     - name: Install tox
@@ -31,10 +31,10 @@ jobs:
           - {platform: ubuntu-latest, python-version: "3.11"}
           - {platform: windows-latest, python-version: "3.11"}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Set up Python ${{ matrix.config.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -56,12 +56,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         # setuptools_scm requires the git clone to not be 'shallow'
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.x"
     - name: Install dependencies
@@ -92,7 +92,7 @@ jobs:
         fi
     - name: Create GitHub release
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       env:
         # This token is provided by Actions, you do not need to create your own token
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.12"
     - name: Install tox
       run: pip install tox
     - name: Run style and typing checks

--- a/src/nanoemoji/write_config_for_mergeable.py
+++ b/src/nanoemoji/write_config_for_mergeable.py
@@ -34,9 +34,7 @@ def main(argv):
     descender = font["OS/2"].sTypoDescender
 
     with open(config_file, "w") as f:
-        f.write(
-            textwrap.dedent(
-                f"""
+        f.write(textwrap.dedent(f"""
             output_file = "COLR.ttf"
             color_format = "{FLAGS.color_format}"
             upem = {upem}
@@ -56,9 +54,7 @@ def main(argv):
 
             [master.regular.position]
             wght = 400
-            """
-            )
-        )
+            """))
 
 
 if __name__ == "__main__":

--- a/src/nanoemoji/write_diffreport.py
+++ b/src/nanoemoji/write_diffreport.py
@@ -52,9 +52,7 @@ def main(argv):
     )
     diff_files = sorted(diff_files, key=_diff_value, reverse=True)
     with open(FLAGS.output_file, "w") as f:
-        f.write(
-            dedent(
-                """
+        f.write(dedent("""
         <!DOCTYPE html>
         <html>
         <head>
@@ -82,9 +80,7 @@ def main(argv):
                 <span class="title">Pink Diff</span>
                 <span class="title">COLRv1</span>
             </div>
-        """
-            )
-        )
+        """))
         for diff_file in diff_files[: FLAGS.report_max_entries]:
             logging.info("%s %s", diff_file.name, _diff_value(diff_file))
             pink_diff = diff_file.parent / (diff_file.stem + ".pink" + diff_file.suffix)
@@ -95,9 +91,7 @@ def main(argv):
                 "diff_file2": str(pink_diff),
                 "filename": diff_file.name,
             }
-            f.write(
-                dedent(
-                    """
+            f.write(dedent("""
             <div class="row">
                 <div class="filename">{filename}</div>
                 <img src="{lhs_file}">
@@ -105,21 +99,13 @@ def main(argv):
                 <img src="{diff_file2}">
                 <img src="{rhs_file}">
             </div>
-            """.format(
-                        **vars
-                    )
-                )
-            )
+            """.format(**vars)))
 
-        f.write(
-            dedent(
-                """
+        f.write(dedent("""
         </body>
 
         </html>
-        """
-            )
-        )
+        """))
 
 
 if __name__ == "__main__":

--- a/src/nanoemoji/write_font2png_html.py
+++ b/src/nanoemoji/write_font2png_html.py
@@ -77,9 +77,7 @@ def main(argv):
 
                 }
             </script>
-        """.replace(
-                    "FONT_LOCATION", font_file
-                )
+        """.replace("FONT_LOCATION", font_file)
                 .replace("RESOLUTION", str(FLAGS.resolution))
                 .replace("ACTIVATION", activation)
             )

--- a/tests/features_test.py
+++ b/tests/features_test.py
@@ -6,8 +6,7 @@ import pytest
 @pytest.mark.parametrize("feature_tag", (DEFAULT_GSUB_FEATURE_TAG, "rlig"))
 def test_generate_fea(feature_tag):
     rgi_sequences = [(0x1F64C,), (0x1F64C, 0x1F3FB), (0x1F64C, 0x1F3FC)]
-    assert generate_fea(rgi_sequences, feature_tag=feature_tag) == dedent(
-        f"""\
+    assert generate_fea(rgi_sequences, feature_tag=feature_tag) == dedent(f"""\
         languagesystem DFLT dflt;
         languagesystem latn dflt;
 
@@ -15,5 +14,4 @@ def test_generate_fea(feature_tag):
           sub g_1f64c g_1f3fb by g_1f64c_1f3fb;
           sub g_1f64c g_1f3fc by g_1f64c_1f3fc;
         }} {feature_tag};
-        """
-    )
+        """)

--- a/tests/parts_test.py
+++ b/tests/parts_test.py
@@ -65,50 +65,42 @@ def _from_svg(svg, view_box=None) -> ReusableParts:
 
 
 def test_add_svg():
-    parts = _from_svg(
-        """
+    parts = _from_svg("""
         <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
              xmlns:xlink="http://www.w3.org/1999/xlink">
           <rect x="2" y="2" width="6" height="2" fill="blue" />
           <rect x="4" y="4" width="6" height="2" fill="blue" opacity="0.8" />
         </svg>
-        """
-    )
+        """)
     check_num_shapes(parts, 1)
 
 
 def test_collects_normalized_shapes():
-    parts = _from_svg(
-        """
+    parts = _from_svg("""
         <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
           <rect width="2" height="1"/>
           <rect width="4" height="2" y="1.5"/>
           <circle cx="5" cy="5" r="2"/>
         </svg>
-        """
-    )
+        """)
 
     check_num_shapes(parts, 2)
 
 
 def test_simple_merge():
-    p1 = _from_svg(
-        """
+    p1 = _from_svg("""
         <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
           <rect width="2" height="1"/>
         </svg>
-        """
-    )
+        """)
     check_num_shapes(p1, 1)
 
-    p2 = _from_svg(
-        """
+    p2 = _from_svg("""
         <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
           <rect width="4" height="2" y="1.5"/>
           <circle r="2"/>
         </svg>
-        """
-    )
+        """)
     check_num_shapes(p2, 2)
 
     p1.add(p2)
@@ -131,23 +123,19 @@ def test_file_io():
 @pytest.mark.parametrize(
     "svg",
     [
-        SVG.fromstring(
-            """
+        SVG.fromstring("""
             <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
               <rect width="2" height="1"/>
               <rect width="4" height="2" y="1.5"/>
             </svg>
-            """
-        ).topicosvg(),
+            """).topicosvg(),
         # https://github.com/googlefonts/nanoemoji/issues/415 arc normalization
-        SVG.fromstring(
-            """
+        SVG.fromstring("""
             <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
               <circle r="1"/>
               <circle r="2"/>
             </svg>
-            """
-        ).topicosvg(),
+            """).topicosvg(),
     ],
 )
 def test_reuse_finds_single_donor(svg):
@@ -193,14 +181,12 @@ def test_reuse_with_inconsistent_square_viewbox():
 
 
 def test_arcs_become_cubics():
-    parts = _from_svg(
-        """
+    parts = _from_svg("""
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
           <defs/>
           <path d="M2,0 A2 2 0 1 1 -2,0 A2 2 0 1 1 2,0 Z"/>
         </svg>
-        """
-    )
+        """)
 
     norm, path = only(parts.shape_sets.items())
     path = only(path)
@@ -263,14 +249,12 @@ def test_negative_tolerance_no_reuse():
     because _compute_donor passed -1 tolerance through to affine_between).
 
     See https://github.com/googlefonts/picosvg/pull/334"""
-    svg = SVG.fromstring(
-        """
+    svg = SVG.fromstring("""
         <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
           <rect width="2" height="1"/>
           <rect width="4" height="2" y="1.5"/>
         </svg>
-        """
-    ).topicosvg()
+        """).topicosvg()
 
     # With positive tolerance these two rects normalize to the same shape
     reuse_parts = ReusableParts(view_box=Rect(0, 0, 10, 10), reuse_tolerance=0.1)

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ description = Check python style and typing annotation
 extras = lint
 usedevelop = true
 ; use the latest python that pytype supports
-basepython = python3.9
+basepython = python3.12
 commands =
     black --check --diff src tests
     pytype


### PR DESCRIPTION
Closes #495. tox.ini pinned the lint env to python3.9 because that was the latest pytype supported at the time; pytype's own FAQ (google/pytype#1925) now names 3.12 as the last version it supports, so bumped to that. That also changes which black version tox resolves (25.11.0 -> 26.5.1), hence the separate black commit. Verified locally: tox -e lint clean and full pytest suite (285 passed, 16 skipped) on 3.12.