### PR TITLE
misc bugfixes independent of type-checker migration

### DIFF
--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -441,7 +441,7 @@ def load(
         if not source_names:
             source_names = master_source_names
         elif source_names != master_source_names:
-            raise ValueError(f"{fonts[i].name} srcs don't match {fonts[0].name}")
+            raise ValueError(f"{master.name} srcs don't match {masters[0].name}")
 
     if not masters:
         raise ValueError("Must have at least one master")

--- a/src/nanoemoji/nanoemoji.py
+++ b/src/nanoemoji/nanoemoji.py
@@ -467,7 +467,9 @@ def write_svg_font_diff_build(
     font_for_screenshots = font2png_dir() / "Font.ttf"
     nw.build(font_for_screenshots, "copy_font_to_screenshot_dir", font_dest)
 
-    # make an html container for each input in the font
+    # make an html container for each input in the font; font2png_html_dest()
+    # isn't resolution-specific, so render at the highest requested resolution
+    max_resolution = max(resolutions)
     for svg_file in svg_files:
         inputs = [
             font_for_screenshots,
@@ -477,7 +479,7 @@ def write_svg_font_diff_build(
             font2png_html_dest(svg_file),
             "write_font2png_html",
             inputs,
-            variables={"res": resolution},
+            variables={"res": max_resolution},
         )
     nw.newline()
 

--- a/src/nanoemoji/write_font.py
+++ b/src/nanoemoji/write_font.py
@@ -431,13 +431,6 @@ def _name_prefix(color_glyph: ColorGlyph) -> Glyph:
 def _init_glyph(color_glyph: ColorGlyph) -> Glyph:
     ufo = color_glyph.ufo
     glyph = ufo.newGlyph(_next_name(ufo, lambda i: f"{_name_prefix(color_glyph)}{i}"))
-    glyph.width = ufo.get(color_glyph.glyph_name).width
-    return glyph
-
-
-def _init_glyph(color_glyph: ColorGlyph) -> Glyph:
-    ufo = color_glyph.ufo
-    glyph = ufo.newGlyph(_next_name(ufo, lambda i: f"{_name_prefix(color_glyph)}{i}"))
     glyph.width = color_glyph.ufo_glyph.width
     return glyph
 


### PR DESCRIPTION
Three small pre-existing bugs found while working on the type-checker migration (#497), independent of which checker we end up with:

- config.py's "srcs don't match" error message referenced undefined names (`fonts[i]`/`fonts[0]`), so hitting that raised NameError instead of the intended ValueError.
- write_svg_font_diff_build read `resolution` after the loop that defined it had ended; it happened to equal max(resolutions) because Python leaks loop variables, but would `UnboundLocalError` on an empty set. Now it uses an explicit `max_resolution`.
- write_font.py defined `_init_glyph` twice; Python silently keeps the second. The shadowed first one was unreachable and broken; now deleted.


