### PR TITLE
Drop Python 3.8 and 3.9, require 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
     strategy:
       matrix:
         config:
-          - {platform: ubuntu-latest, python-version: "3.8"}
-          - {platform: ubuntu-latest, python-version: "3.9"}
           - {platform: ubuntu-latest, python-version: "3.10"}
           - {platform: ubuntu-latest, python-version: "3.11"}
-          - {platform: windows-latest, python-version: "3.11"}
+          - {platform: ubuntu-latest, python-version: "3.12"}
+          - {platform: ubuntu-latest, python-version: "3.13"}
+          - {platform: ubuntu-latest, python-version: "3.14"}
+          - {platform: windows-latest, python-version: "3.14"}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ nanoemoji --helpfull
 nanoemoji --color_format glyf_colr_1 $(find ../noto-emoji/svg -name 'emoji_u270d*.svg')
 ```
 
-Requires Python 3.8 or greater.
+Requires Python 3.10 or greater.
 
 ## Color table support
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     install_requires=[
         "absl-py>=0.9.0",
         "fonttools[ufo]>=4.36.0",
-        "importlib_resources>=3.3.0; python_version < '3.9'",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
         "picosvg>=0.22.1",
@@ -53,7 +52,7 @@ setup(
         "pngquant-cli>=2.17.0.post5",
     ],
     extras_require=extras_require,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
 
     # this is for type checker to use our inline type hints:
     # https://www.python.org/dev/peps/pep-0561/#id18

--- a/src/nanoemoji/config.py
+++ b/src/nanoemoji/config.py
@@ -14,10 +14,7 @@
 
 from absl import flags
 
-try:
-    import importlib.resources as resources  # pytype: disable=import-error
-except ImportError:
-    import importlib_resources as resources  # pytype: disable=import-error
+import importlib.resources as resources
 
 import itertools
 from pathlib import Path

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@
 ;     # Runs static checks, then pytest for all the pythons listed in 'envlist'
 ;   $ tox -e lint
 ;     # Only runs the linter checks
-;   $ tox -e py38
-;     # Runs all tests against python3.8 only
+;   $ tox -e py310
+;     # Runs all tests against python3.10 only
 ;   $ tox -e py
 ;     # Runs tests against the current python in which tox itself was installed
-;   $ export TOXENV=py39
+;   $ export TOXENV=py311
 ;   $ tox
 ;     # If present use $TOXENV environment variable
-envlist = lint, py3{8,9,10,11}
+envlist = lint, py3{10,11,12,13,14}
 
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error
@@ -24,7 +24,7 @@ extras = test
 ; downloads the latest pip, setuptools and wheel when creating the venv
 download = true
 ; any arguments passed to tox command line after the '--' separator are passed through
-; to pytest: e.g. `tox -e py39 -- -vv --lf -x`
+; to pytest: e.g. `tox -e py311 -- -vv --lf -x`
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
Drops Python 3.8 and 3.9 and sets the floor at 3.10 (same as fontTools).

Both are past end of life (3.8 in October 2024, 3.9 in October 2025).

Drops the `importlib_resources` backport dependency (for < 3.9). Also fills the gap at the top of the CI matrix: Linux now tests every supported minor (3.10 through 3.14) and Windows moves to the latest stable, 3.14.