### PR TITLE
Drop Vector casts made redundant by picosvg 0.23.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "fonttools[ufo]>=4.36.0",
         "lxml>=4.0",
         "ninja>=1.10.0.post1",
-        "picosvg>=0.22.1",
+        "picosvg>=0.23.0",
         "pillow>=7.2.0",
         "regex>=2020.4.4",
         "toml>=0.10.1",

--- a/src/nanoemoji/color_glyph.py
+++ b/src/nanoemoji/color_glyph.py
@@ -32,7 +32,7 @@ from nanoemoji.paint import (
     PaintSolid,
 )
 from nanoemoji.png import PNG
-from picosvg.geometric_types import Point, Rect, Vector
+from picosvg.geometric_types import Point, Rect
 from picosvg.svg_meta import number_or_percentage
 from picosvg.svg_reuse import normalize, affine_between
 from picosvg.svg_transform import Affine2D
@@ -44,7 +44,6 @@ from picosvg.svg_types import (
     intersection,
 )
 from typing import (
-    cast,
     Any,
     Dict,
     Generator,
@@ -148,9 +147,7 @@ def _parse_linear_gradient(
     p1 = Point(gradient.x2, gradient.y2)
 
     # Set P2 to P1 rotated 90 degrees counter-clockwise around P0
-    # Point.__sub__ is annotated Point | Vector; subtracting two Points
-    # always yields a Vector
-    p2 = p0 + cast(Vector, p1 - p0).perpendicular()
+    p2 = p0 + (p1 - p0).perpendicular()
 
     common_args = _common_gradient_parts(grad_el, shape_opacity)
 

--- a/src/nanoemoji/paint.py
+++ b/src/nanoemoji/paint.py
@@ -32,10 +32,9 @@ from nanoemoji.fixed import (
     MIN_UINT16,
     MAX_UINT16,
 )
-from picosvg.geometric_types import Point, Vector, almost_equal
+from picosvg.geometric_types import Point, almost_equal
 from picosvg.svg_transform import Affine2D
 from typing import (
-    cast,
     Any,
     ClassVar,
     Dict,
@@ -232,9 +231,7 @@ class PaintLinearGradient(Paint):
         if self.p2 is None:
             p0, p1 = Point(*self.p0), Point(*self.p1)
             # use object.__setattr__ as the dataclass is frozen
-            # Point.__sub__ is annotated Point | Vector; subtracting two Points
-            # always yields a Vector
-            object.__setattr__(self, "p2", p0 + cast(Vector, p1 - p0).perpendicular())
+            object.__setattr__(self, "p2", p0 + (p1 - p0).perpendicular())
 
     def colors(self):
         for stop in self.stops:

--- a/src/nanoemoji/svg.py
+++ b/src/nanoemoji/svg.py
@@ -40,7 +40,7 @@ from nanoemoji.paint import (
     PaintTraverseContext,
     is_transform,
 )
-from picosvg.geometric_types import Rect, Vector
+from picosvg.geometric_types import Rect
 from nanoemoji.reorder_glyphs import reorder_glyphs
 from picosvg.svg import to_element, SVG
 from picosvg import svg_meta
@@ -297,9 +297,7 @@ def _define_linear_gradient(
     # (projection of P1 onto perpendicular to normal) is == P1 itself thus no rotation.
     # When P2 is collinear to the P1-P0 gradient vector, then this projected P3 == P0
     # and the gradient degenerates to a solid paint (the last color stop).
-    # Point.__sub__ is annotated Point | Vector; subtracting two Points
-    # always yields a Vector
-    p3 = p0 + cast(Vector, p1 - p0).projection(cast(Vector, p2 - p0).perpendicular())
+    p3 = p0 + (p1 - p0).projection((p2 - p0).perpendicular())
 
     x1, y1 = p0
     x2, y2 = p3


### PR DESCRIPTION
picosvg's `Point.__sub__` is now overloaded so `Point - Point` is statically a `Vector` and the casts can go.

Requires picosvg 0.23.0.